### PR TITLE
feat(mcv): add Military Conflict: Vietnam cvarlist

### DIFF
--- a/mcv-cvarlist.txt
+++ b/mcv-cvarlist.txt
@@ -1,0 +1,2481 @@
+cvar list
+--------------
+_resetgamestats                          : cmd      :                  : Erases current game stats and writes out a blank stats file
+_restart                                 : cmd      :                  : Shutdown and restart the engine.
+achievement_debug                        : 0        : , "sv", "cheat", "rep" : Turn on achievement debug msgs.
+achievement_disable                      : 0        : , "sv", "cheat", "rep" : Turn off achievements.
+addip                                    : cmd      :                  : Add an IP address to the ban list.
+ai_auto_contact_solver                   : 1        : , "sv"           :
+ai_block_damage                          : 0        : , "sv"           :
+ai_clear_bad_links                       : cmd      :                  : Clears bits set on nav links indicating link is unusable
+ai_debug_assault                         : 0        : , "sv"           :
+ai_debug_avoidancebounds                 : 0        : , "sv"           :
+ai_debug_directnavprobe                  : 0        : , "sv"           :
+ai_debug_doors                           : 0        : , "sv"           :
+ai_debug_dyninteractions                 : 0        : , "sv"           : Debug the NPC dynamic interaction system.
+ai_debug_efficiency                      : 0        : , "sv"           :
+ai_debug_enemies                         : 0        : , "sv"           :
+ai_debug_expressions                     : 0        : , "sv"           : Show random expression decisions for NPCs.
+ai_debug_follow                          : 0        : , "sv"           :
+ai_debug_loners                          : 0        : , "sv"           :
+ai_debug_looktargets                     : 0        : , "sv"           :
+ai_debug_los                             : 0        : , "sv", "cheat"  : NPC Line-Of-Sight debug mode. If 1, solid entities that block NPC LOC will be highlighted with white bounding boxes. If 2, it'l
+ai_debug_nav                             : 0        : , "sv"           :
+ai_debug_node_connect                    : cmd      :                  : Debug the attempted connection between two nodes
+ai_debug_ragdoll_magnets                 : 0        : , "sv"           :
+ai_debug_shoot_positions                 : 0        : , "sv", "cheat", "rep" :
+ai_debug_speech                          : 0        : , "sv"           :
+ai_debug_squads                          : 0        : , "sv"           :
+ai_debug_think_ticks                     : 0        : , "sv"           :
+ai_debugscriptconditions                 : 0        : , "sv"           :
+ai_default_efficient                     : 0        : , "sv"           :
+ai_disable                               : cmd      :                  : Bi-passes all AI logic routines and puts all NPCs into their idle animations.  Can be used to get NPCs out of your way and to t
+ai_drawbattlelines                       : 0        : , "sv", "cheat"  :
+ai_drop_hint                             : cmd      :                  : Drop an ai_hint at the player's current eye position.
+ai_dump_hints                            : cmd      :                  :
+ai_efficiency_override                   : 0        : , "sv"           :
+ai_enable_fear_behavior                  : 1        : , "sv"           :
+ai_expression_frametime                  : 0        : , "sv"           : Maximum frametime to still play background expressions.
+ai_expression_optimization               : 0        : , "sv"           : Disable npc background expressions when you can't see them.
+ai_fear_player_dist                      : 720      : , "sv"           :
+ai_find_lateral_cover                    : 1        : , "sv"           :
+ai_find_lateral_los                      : 1        : , "sv"           :
+ai_follow_use_points                     : 1        : , "sv"           :
+ai_follow_use_points_when_moving         : 1        : , "sv"           :
+ai_force_serverside_ragdoll              : 0        : , "sv"           :
+ai_frametime_limit                       : 50       : , "sv"           : frametime limit for min efficiency AIE_NORMAL (in sec's).
+ai_hull                                  : cmd      :                  : Controls which connections are shown when ai_show_hull or ai_show_connect commands are used  Arguments: NPC name or classname,
+ai_inhibit_spawners                      : 0        : , "sv", "cheat"  :
+ai_lead_time                             : 0        : , "sv"           :
+ai_LOS_mode                              : 0        : , "sv", "rep"    :
+ai_moveprobe_debug                       : 0        : , "sv"           :
+ai_moveprobe_jump_debug                  : 0        : , "sv"           :
+ai_moveprobe_usetracelist                : 0        : , "sv"           :
+ai_nav_debug_experimental_pathing        : 0        : , "sv"           : Draw paths tried during search for bodysnatcher pathing
+ai_navigator_generate_spikes             : 0        : , "sv"           :
+ai_navigator_generate_spikes_strength    : 8        : , "sv"           :
+ai_next_hull                             : cmd      :                  : Cycles through the various hull sizes.  Currently selected hull size is written to the screen.  Controls which connections are
+ai_no_local_paths                        : 0        : , "sv"           :
+ai_no_node_cache                         : 0        : , "sv"           :
+ai_no_select_box                         : 0        : , "sv"           :
+ai_no_steer                              : 0        : , "sv"           :
+ai_no_talk_delay                         : 0        : , "sv"           :
+ai_nodes                                 : cmd      :                  : Toggles node display.  First call displays the nodes for the given network as green objects.  Second call  displays the nodes a
+ai_norebuildgraph                        : 0        : , "sv"           :
+ai_path_adjust_speed_on_immediate_turns  : 1        : , "sv"           :
+ai_path_insert_pause_at_est_end          : 1        : , "sv"           :
+ai_path_insert_pause_at_obstruction      : 1        : , "sv"           :
+ai_post_frame_navigation                 : 0        : , "sv"           :
+ai_radial_max_link_dist                  : 512      : , "sv"           :
+ai_reaction_delay_alert                  : 0        : , "sv"           :
+ai_reaction_delay_idle                   : 0        : , "sv"           :
+ai_rebalance_thinks                      : 1        : , "sv"           :
+ai_report_task_timings_on_limit          : 0        : , "a", "sv"      :
+ai_resume                                : cmd      :                  : If NPC is stepping through tasks (see ai_step ) will resume normal processing.
+ai_sequence_debug                        : 0        : , "sv"           :
+ai_set_move_height_epsilon               : cmd      :                  : Set how high AI bumps up ground walkers when checking steps
+ai_setenabled                            : cmd      :                  : Like ai_disable but you manually specify the state (with a 0 or 1) instead of toggling it.
+ai_setupbones_debug                      : 0        : , "sv"           : Shows that bones that are setup every think
+ai_shot_bias                             : 1        : , "sv"           :
+ai_shot_bias_max                         : 1        : , "sv", "rep"    :
+ai_shot_bias_min                         : -1       : , "sv", "rep"    :
+ai_shot_stats                            : 0        : , "sv"           :
+ai_shot_stats_term                       : 1000     : , "sv"           :
+ai_show_connect                          : cmd      :                  : Displays the allowed connections between each node for the currently selected hull type.  Hulls are color code as follows:  Gre
+ai_show_connect_crawl                    : cmd      :                  : Displays the allowed connections between each node for the currently selected hull type.  Hulls are color code as follows:  Gre
+ai_show_connect_fly                      : cmd      :                  : Displays the allowed connections between each node for the currently selected hull type.  Hulls are color code as follows:  Gre
+ai_show_connect_jump                     : cmd      :                  : Displays the allowed connections between each node for the currently selected hull type.  Hulls are color code as follows:  Gre
+ai_show_graph_connect                    : cmd      :                  : Toggles graph connection display for the node that the player is looking at.  Nodes that are connected to the selected node by
+ai_show_grid                             : cmd      :                  : Draw a grid on the floor where looking.
+ai_show_hints                            : cmd      :                  : Displays all hints as small boxes  Blue  - hint is available for use  Red  - hint is currently being used by an NPC  Orange  -
+ai_show_hull                             : cmd      :                  : Displays the allowed hulls between each node for the currently selected hull type.  Hulls are color code as follows:  Green  -
+ai_show_hull_attacks                     : 0        : , "sv"           :
+ai_show_node                             : cmd      :                  : Highlight the specified node
+ai_show_think_tolerance                  : 0        : , "sv"           :
+ai_show_visibility                       : cmd      :                  : Toggles visibility display for the node that the player is looking at.  Nodes that are visible from the selected node will be d
+ai_simulate_task_overtime                : 0        : , "sv"           :
+ai_spread_cone_focus_time                : 0        : , "sv"           :
+ai_spread_defocused_cone_multiplier      : 3        : , "sv"           :
+ai_spread_pattern_focus_time             : 0        : , "sv"           :
+ai_step                                  : cmd      :                  : NPCs will freeze after completing their current task.  To complete the next task, use 'ai_step' again.  To resume processing no
+ai_strong_optimizations                  : 0        : , "sv"           :
+ai_strong_optimizations_no_checkstand    : 0        : , "sv"           :
+ai_task_pre_script                       : 0        : , "sv"           :
+ai_test_los                              : cmd      :                  : Test AI LOS from the player's POV
+ai_test_moveprobe_ignoresmall            : 0        : , "sv"           :
+ai_think_limit_label                     : 0        : , "a", "sv"      :
+ai_use_clipped_paths                     : 1        : , "sv"           :
+ai_use_efficiency                        : 1        : , "sv"           :
+ai_use_frame_think_limits                : 1        : , "sv"           :
+ai_use_think_optimizations               : 1        : , "sv"           :
+ai_use_visibility_cache                  : 1        : , "sv"           :
+ai_vehicle_avoidance                     : 1        : , "sv", "cheat"  :
+ainet_generate_report                    : cmd      :                  : Generate a report to the console.
+ainet_generate_report_only               : cmd      :                  : Generate a report to the console.
+air_density                              : cmd      :                  : Changes the density of air for drag computations.
+alias                                    : cmd      :                  : Alias a command.
+anim_3wayblend                           : 1        : , "sv", "rep"    : Toggle the 3-way animation blending code.
+anim_twistbones_enabled                  : 0        : , "sv", "cheat", "rep" : Enable procedural twist bones.
+async_allow_held_files                   : 1        :                  : Allow AsyncBegin/EndRead()
+async_mode                               : 0        :                  : Set the async filesystem mode (0 = async, 1 = synchronous)
+async_resume                             : cmd      :                  :
+async_serialize                          : 0        :                  : Force async reads to serialize for profiling
+async_simulate_delay                     : 0        :                  : Simulate a delay of up to a set msec per file operation
+async_suspend                            : cmd      :                  :
+autoaim_max_deflect                      : 0        : , "sv"           :
+autoaim_max_dist                         : 2160     : , "sv"           :
+banid                                    : cmd      :                  : Add a user ID to the ban list.
+banip                                    : cmd      :                  : Add an IP address to the ban list.
+bind                                     : cmd      :                  : Bind a key.
+bind_osx                                 : cmd      :                  : Bind a key for OSX only.
+BindToggle                               : cmd      :                  : Performs a bind <key> 'increment var <cvar> 0 1 1'
+blackbox_record                          : cmd      :                  : Record an entry into the blackbox
+BlendBonesMode                           : 2        : , "sv", "rep"    :
+bot_add                                  : cmd      :                  : bot_add <t|ct> <type> <difficulty> <name> - Adds a bot matching the given criteria.
+bot_add_2_per_team                       : cmd      :                  : bot_add_2_per_team - Adds two bots to each team.
+bot_add_4_per_team                       : cmd      :                  : bot_add_4_per_team - Adds four bots to each team.
+bot_add_6_per_team                       : cmd      :                  : bot_add_6_per_team - Adds six bots to each team.
+bot_add_usa                              : cmd      :                  : bot_add_usa <type> <difficulty> <name> - Adds a USA bot matching the given criteria.
+bot_add_vc                               : cmd      :                  : bot_add_vc <type> <difficulty> <name> - Adds a Viet Cong bot matching the given criteria.
+bot_all_weapons                          : cmd      :                  : Allows the bots to use all weapons
+bot_allow_crossbow                       : 1        : , "sv", "rep"    : If nonzero, bots may use crossbow.
+bot_allow_equipment                      : 1        : , "sv", "rep"    : If nonzero, bots may use equipment (ammo/medic boxes, flareguns, flamethrowers).
+bot_allow_grenades                       : 1        : , "sv", "rep"    : If nonzero, bots may use grenades.
+bot_allow_machine_guns                   : 1        : , "sv", "rep"    : If nonzero, bots may use the machine gun.
+bot_allow_mines                          : 1        : , "sv", "rep"    : If nonzero, bots may use mines.
+bot_allow_pistols                        : 1        : , "sv", "rep"    : If nonzero, bots may use pistols.
+bot_allow_rifles                         : 1        : , "sv", "rep"    : If nonzero, bots may use rifles.
+bot_allow_rocket_launchers               : 1        : , "sv", "rep"    : If nonzero, bots may use rocket launchers.
+bot_allow_rogues                         : 0        : , "sv", "rep"    : If nonzero, bots may occasionally go 'rogue'. Rogue bots do not obey radio commands, nor pursue scenario goals.
+bot_allow_shotguns                       : 1        : , "sv", "rep"    : If nonzero, bots may use shotguns.
+bot_allow_snipers                        : 1        : , "sv", "rep"    : If nonzero, bots may use sniper rifles.
+bot_allow_sub_machine_guns               : 1        : , "sv", "rep"    : If nonzero, bots may use sub-machine guns.
+bot_auto_follow                          : 0        : , "sv", "rep"    : If nonzero, bots with high co-op may automatically follow a nearby human player.
+bot_auto_vacate                          : 1        : , "sv", "rep"    : If nonzero, bots will automatically leave to make room for human players.
+bot_autodifficulty_threshold_high        : 5        : , "sv", "rep"    : Upper bound above Average Human Contribution Score that a bot must be above to change its difficulty
+bot_autodifficulty_threshold_low         : -2       : , "sv", "rep"    : Lower bound below Average Human Contribution Score that a bot must be below to change its difficulty
+bot_chatter                              : 0        : , "sv", "rep"    : Control how bots talk. Allowed values: 'off', 'radio', 'minimal', or 'normal'.
+bot_controllable                         : 1        : , "sv", "rep"    : Determines whether bots can be controlled by players
+bot_coop_idle_max_vision_distance        : 1400     : , "sv", "cheat", "rep" : Max distance bots can see targets (in coop) when they are idle, dormant, hiding or asleep.
+bot_crouch                               : 0        : , "sv", "cheat"  :
+bot_debug                                : 0        : , "sv", "cheat", "rep" : For internal testing purposes.
+bot_debug_target                         : 0        : , "sv", "cheat", "rep" : For internal testing purposes.
+bot_defer_to_human_goals                 : 0        : , "sv", "rep"    : If nonzero and there is a human on the team, the bots will not do the scenario tasks.
+bot_defer_to_human_items                 : 1        : , "sv", "rep"    : If nonzero and there is a human on the team, the bots will not get scenario items.
+bot_difficulty                           : 1        : , "sv", "rep"    : Defines the skill of bots joining the game.  Values are: -1=random, 0=very easy, 1=easy, 2=normal, 3=hard, 4=veryhard, 5=expert
+bot_disconnect                           : cmd      :                  : Random bot disconnects from the game. Useful for emulating client disconnection.
+bot_dont_shoot                           : 0        : , "sv", "cheat", "rep" : If nonzero, bots will not fire weapons (for debugging).
+bot_fill_both_teams                      : cmd      :                  : bot_fill_both_teams - Fills both teams with bots.
+bot_fists_only                           : 0        : , "sv", "rep"    : Start a fist fight among bots
+bot_flipout                              : 0        : , "sv", "rep"    : If nonzero, bots use no CPU for AI. Instead, they run around randomly.
+bot_force_duck                           : 0        : , "sv"           :
+bot_force_prone                          : 0        : , "sv"           :
+bot_freeze                               : 0        : , "sv", "cheat"  :
+bot_goto_mark                            : cmd      :                  : Sends a bot to the marked nav area (useful for testing navigation meshes)
+bot_goto_selected                        : cmd      :                  : Sends a bot to the selected nav area (useful for testing navigation meshes)
+bot_humanteam_playercount                : 6        : , "sv", "rep"    : Adds or removes bots to keep given player count on human team.
+bot_ignore_players                       : 0        : , "sv", "cheat"  : Bots will not see non-bot players.
+bot_join_after_player                    : 0        : , "sv", "rep"    : If nonzero, bots wait until a player joins before entering the game.
+bot_join_delay                           : 0        : , "sv"           : Prevents bots from joining the server for this many seconds after a map change.
+bot_join_in_warmup                       : 1        : , "sv"           : Prevents bots from joining the server while warmup phase is active.
+bot_join_no_navmesh                      : 0        : , "sv"           : Allow bots to join if no nav mesh is present on the map.
+bot_join_team                            : 0        : , "sv", "rep"    : Determines the team bots will join into. Allowed values: 'any', 'VC', or 'US'.
+bot_kick                                 : cmd      :                  : bot_kick <all> <t|ct> <type> <difficulty> <name> - Kicks a specific bot, or all bots, matching the given criteria.
+bot_kick_2_per_team                      : cmd      :                  : Removes 2 random bots from both teams.
+bot_kick_4_per_team                      : cmd      :                  : Removes 4 random bots from both teams.
+bot_kick_6_per_team                      : cmd      :                  : Removes 6 random bots from both teams.
+bot_kick_usa                             : cmd      :                  : Removes random bot from United States team.
+bot_kick_vc                              : cmd      :                  : Removes random bot from Viet Cong team.
+bot_kill                                 : cmd      :                  : bot_kill <all> <t|ct> <type> <difficulty> <name> - Kills a specific bot, or all bots, matching the given criteria.
+bot_knives_only                          : cmd      :                  : Restricts the bots to only using knives
+bot_limit_computepath_calls              : 24       : , "sv"           : Limit ComputePath calls perframe count to this value.
+bot_max_vision_distance_override         : -1       : , "sv", "cheat", "rep" : Max distance bots can see targets.
+bot_mimic                                : 0        : , "sv", "cheat"  :
+bot_mimic_yaw_offset                     : 180      : , "sv", "cheat"  :
+bot_no_backup                            : 0        : , "sv", "rep"    : Prohibit usage of 'Need Backup' voice command .
+bot_pistols_only                         : cmd      :                  : Restricts the bots to only using pistols
+bot_place                                : cmd      :                  : bot_place - Places a bot from the map at where the local player is pointing.
+bot_prefix                               : 0        : , "sv", "rep"    : This string is prefixed to the name of all bots that join the game. <difficulty> will be replaced with the bot's difficulty. <w
+bot_profile_db                           : 0        : , "sv", "rep"    : The filename from which bot profiles will be read.
+bot_prone                                : 0        : , "sv", "cheat"  :
+bot_quota                                : 12       : , "sv", "rep"    : Determines the total number of bots in the game.
+bot_quota_mode                           : 0        : , "sv", "rep"    : Determines the type of quota. Allowed values: 'normal', 'fill', and 'match'. If 'fill', the server will adjust bots to keep N p
+bot_quota_us                             : 0        : , "sv", "rep"    : Determines the total number of bots in the US team.
+bot_quota_vc                             : 0        : , "sv", "rep"    : Determines the total number of bots in the VC team.
+bot_ratio                                : -1       : , "sv", "rep"    : Determines human/bot ratio.
+bot_show_battlefront                     : 0        : , "sv", "cheat"  : Show areas where rushing players will initially meet.
+bot_show_nav                             : 0        : , "sv", "cheat", "rep" : For internal testing purposes.
+bot_show_occupy_time                     : 0        : , "sv", "cheat"  : Show when each nav area can first be reached by each team.
+bot_snipers_only                         : cmd      :                  : Restricts the bots to only using sniper rifles
+bot_stop                                 : 0        : , "sv", "cheat", "rep" : If nonzero, immediately stops all bot processing.
+bot_throw_knives                         : 1        : , "sv", "rep"    : If nonzero, bots may throw knives (bayonets).
+bot_traceview                            : 0        : , "sv", "cheat", "rep" : For internal testing purposes.
+bot_voicecommand                         : cmd      :                  : bot_voicecommand - Force bots to use a voice command.
+bot_vote                                 : cmd      :                  : For debugging: cast votes in place of bots, distributed or randomly
+bot_walk                                 : 0        : , "sv", "rep"    : If nonzero, bots can only walk, not run.
+bot_zombie                               : 0        : , "sv", "cheat", "rep" : If nonzero, bots will stay in idle mode and not attack.
+breakable_disable_gib_limit              : 0        : , "sv"           :
+breakable_multiplayer                    : 1        : , "sv"           :
+buddha                                   : cmd      :                  : Toggle.  Player takes damage but won't die. (Shows red cross when health is zero)
+budget_toggle_group                      : cmd      :                  : Turn a budget group on/off
+cache_print                              : cmd      :                  : cache_print [section] Print out contents of cache memory.
+cache_print_lru                          : cmd      :                  : cache_print_lru [section] Print out contents of cache memory.
+cache_print_summary                      : cmd      :                  : cache_print_summary [section] Print out a summary contents of cache memory.
+callvote                                 : cmd      :                  : Start a vote on an issue.
+capture_area_drop_progress               : 0        : , "sv", "rep"    : Reset capturing progress instead of slowly running backwards when players leave the area.
+capture_area_no_neutralize               : 0        : , "sv", "rep"    : Capturing enemy flag will not neutralize it, instead it will belong to the capturer team immediately.
+cast_hull                                : cmd      :                  : Tests hull collision detection
+cast_ray                                 : cmd      :                  : Tests collision detection
+cc_norepeat                              : 5        : , "sv"           : In multiplayer games, don't repeat captions more often than this many seconds.
+cc_showmissing                           : 0        : , "sv", "rep"    : Show missing closecaption entries.
+ch_createairboat                         : cmd      :                  : Spawn airboat in front of the player.
+ch_createjeep                            : cmd      :                  : Spawn jeep in front of the player.
+changelevel                              : cmd      :                  : Change server to the specified map
+changelevel2                             : cmd      :                  : Transition to the specified map in single player
+chet_debug_idle                          : 0        : , "a", "sv"      : If set one, many debug prints to help track down the TLK_IDLE issue. Set two for super verbose info
+chicken_debug                            : 0        : , "sv", "cheat"  :
+choreo_spew_filter                       : 0        : , "sv", "rep"    : Spew choreo. Use a sub-string or * to display all events.
+cl_allowdownload                         : 1        : , "a"            : Client downloads customization files
+cl_clock_correction                      : 1        : , "cheat"        : Enable/disable clock correction on the client.
+cl_clock_correction_adjustment_max_amount : 200      : , "cheat"        : Sets the maximum number of milliseconds per second it is allowed to correct the client clock. It will only correct this amount
+cl_clock_correction_adjustment_max_offset : 90       : , "cheat"        : As the clock offset goes from cl_clock_correction_adjustment_min_offset to this value (in milliseconds), it moves towards apply
+cl_clock_correction_adjustment_min_offset : 10       : , "cheat"        : If the clock offset is less than this amount (in milliseconds), then no clock correction is applied.
+cl_clock_correction_force_server_tick    : 999      : , "cheat"        : Force clock correction to match the server tick + this offset (-999 disables it).
+cl_clock_showdebuginfo                   : 0        : , "cheat"        : Show debugging info about the clock drift.
+cl_clockdrift_max_ms                     : 150      : , "cheat"        : Maximum number of milliseconds the clock is allowed to drift before the client snaps its clock to the server's.
+cl_clockdrift_max_ms_threadmode          : 0        : , "cheat"        : Maximum number of milliseconds the clock is allowed to drift before the client snaps its clock to the server's.
+cl_color                                 : 0        : , "a", "user"    : Preferred teammate color
+cl_csm_auto_entity                       : 1        : , "sv"           :
+cl_csm_server_status                     : cmd      :                  : Usage:  cl_csm_server_status
+cl_decryptdata_key                       : 0        :                  : Key to decrypt encrypted GOTV messages
+cl_decryptdata_key_pub                   : 0        :                  : Key to decrypt public encrypted GOTV messages
+cl_hideserverip                          : 0        :                  : If set to 1, server IPs will be hidden in the console (except when you type 'status')
+cl_interpolate                           : 1        :                  : Enables or disables interpolation on listen servers or during demo playback
+cl_resend                                : 2        :                  : Delay in seconds before the client will resend the 'connect' attempt
+cl_resend_timeout                        : 60       :                  : Total time allowed for the client to resend the 'connect' attempt
+cl_simdbones                             : 0        : , "sv", "rep"    : Use SIMD bone setup.
+cl_skipslowpath                          : 0        : , "cheat"        : Set to 1 to skip any models that don't go through the model fast path
+cl_teammate_color_1                      : -13764872 :                  :
+cl_teammate_color_2                      : -1042015 :                  :
+cl_teammate_color_3                      : -10308352 :                  :
+cl_teammate_color_4                      : -22436   :                  :
+cl_teammate_color_5                      : -14312449 :                  :
+cl_use_simd_bones                        : 1        : , "sv", "rep"    : 1 use SIMD bones 0 use scalar bones.
+clear_anim_cache                         : cmd      :                  : Clears the animation cache, freeing the memory (until the next time a streaming animblock is requested).
+clear_debug_overlays                     : cmd      :                  : clears debug overlays
+clientport                               : 27005    :                  : Host game client port
+closecaption                             : 0        : , "a"            : Enable close captioning.
+cmd                                      : cmd      :                  : Forward command to server.
+cmd1                                     : cmd      :                  : sets userinfo string for split screen player in slot 1
+cmd2                                     : cmd      :                  : sets userinfo string for split screen player in slot 2
+cmd3                                     : cmd      :                  : sets userinfo string for split screen player in slot 3
+cmd4                                     : cmd      :                  : sets userinfo string for split screen player in slot 4
+collision_shake_amp                      : 0        : , "sv"           :
+collision_shake_freq                     : 0        : , "sv"           :
+collision_shake_time                     : 0        : , "sv"           :
+collision_test                           : cmd      :                  : Tests collision system
+commentary                               : 0        : , "sv"           : Desired commentary mode state.
+commentary_available                     : 0        : , "sv"           : Automatically set by the game when a commentary file is available for the current map.
+commentary_cvarsnotchanging              : cmd      :                  :
+commentary_finishnode                    : cmd      :                  :
+con_logfile                              : 0        :                  : Console output gets written to this file
+con_timestamp                            : 0        :                  : Prefix console.log entries with timestamps
+contributionscore_hostage_kill           : -2       : , "sv"           : amount of contribution score for killing a hostage, normally negative
+contributionscore_kill                   : 2        : , "sv"           : amount of contribution score added for a kill
+contributionscore_objective_kill         : 1        : , "sv"           : amount of contribution score added for an objective related kill
+contributionscore_suicide                : -2       : , "sv"           : amount of contribution score for a suicide, normally negative
+contributionscore_team_kill              : -2       : , "sv"           : amount of contribution score for a team kill, normally negative
+control_point_world_icons_enabled        : 1        : , "sv"           : Enable HUD icons above flags ingame.
+coop                                     : 0        : , "nf"           : Cooperative play.
+cpu_level                                : 2        :                  : CPU Level - Default: High
+crash                                    : cmd      :                  : Cause the engine to crash (Debug!!)
+create_flashlight                        : cmd      :                  :
+CreatePredictionError                    : cmd      :                  : Create a prediction error
+creditsdone                              : cmd      :                  :
+csm_quality_level                        : 0        :                  : Cascaded shadow map quality level, [0,3], 0=VERY_LOW, 3=HIGHEST
+custom_bot_difficulty                    : 0        : , "sv", "rep", "cl" : Bot difficulty for offline play.
+cvarlist                                 : cmd      :                  : Show the list of convars/concommands.
+datacachesize                            : 32       :                  : Size in MB.
+dbg_demofile                             : 0        :                  :
+dbghist_addline                          : cmd      :                  : Add a line to the debug history. Format: <category id> <line>
+dbghist_dump                             : cmd      :                  : Dump the debug history to the console. Format: <category id>     Categories:      0: Entity I/O      1: AI Decisions      2: Sc
+deathmatch                               : 1        : , "nf"           : Running a deathmatch server.
+debug_dispatch_server_dump               : 0        : , "sv"           :
+debug_map_crc                            : 0        :                  : Prints CRC for each map lump loaded
+debug_materialmodifycontrol              : 0        : , "sv"           :
+debug_math_counter                       : 0        : , "sv", "cheat"  :
+debug_overlay_fullposition               : 0        : , "sv"           :
+debug_physimpact                         : 0        : , "sv"           :
+debug_touchlinks                         : 0        : , "sv"           : Spew touch link activity
+debug_visibility_monitor                 : 0        : , "sv", "cheat"  :
+demo_debug                               : 0        :                  : Demo debug info.
+demo_strict_validation                   : 0        :                  :
+developer                                : 0        :                  : Set developer message level
+devshots_nextmap                         : cmd      :                  : Used by the devshots system to go to the next map in the devshots maplist.
+differences                              : cmd      :                  : Show all convars which are not at their default values.
+disconnect                               : cmd      :                  : Disconnect game from server.
+disp_dynamic                             : 0        :                  :
+disp_list_all_collideable                : cmd      :                  : List all collideable displacements
+dispcoll_drawplane                       : 0        : , "sv"           :
+display_elapsedtime                      : cmd      :                  : Displays how much time has elapsed since the game started
+display_game_events                      : 0        : , "cheat"        :
+displaysoundlist                         : 0        : , "sv"           :
+dm_reset_spawns                          : cmd      :                  :
+drawcross                                : cmd      :                  : Draws a cross at the given location  Arguments: x y z
+drawline                                 : cmd      :                  : Draws line between two 3D Points.  Green if no collision  Red is collides with something  Arguments: x1 y1 z1 x2 y2 z2
+dt_ShowPartialChangeEnts                 : 0        :                  : (SP only) - show entities that were copied using small optimized lists (FL_EDICT_PARTIAL_CHANGE).
+dt_UsePartialChangeEnts                  : 1        :                  : (SP only) - enable FL_EDICT_PARTIAL_CHANGE optimization.
+dti_flush                                : cmd      :                  : Write out the datatable instrumentation files (you must run with -dti for this to work).
+dtwarning                                : 0        :                  : Print data table warnings?
+dtwatchclass                             : 0        :                  : Watch all fields encoded with this table.
+dtwatchdecode                            : 1        :                  : When watching show decode.
+dtwatchencode                            : 1        :                  : When watching show encode.
+dtwatchent                               : -1       :                  : Watch this entities data table encoding.
+dtwatchvar                               : 0        :                  : Watch the named variable.
+dump_entity_sizes                        : cmd      :                  : Print sizeof(entclass)
+dump_globals                             : cmd      :                  : Dump all global entities/states
+dumpentityfactories                      : cmd      :                  : Lists all entity factory names.
+dumpeventqueue                           : cmd      :                  : Dump the contents of the Entity I/O event queue to the console.
+dumpgamestringtable                      : cmd      :                  : Dump the contents of the game string table to the console.
+dumpstringtables                         : cmd      :                  : Print string tables to console.
+echo                                     : cmd      :                  : Echo text to console.
+enable_fast_math                         : 1        :                  : Turns Denormals-Are-Zeroes and Flush-to-Zero on or off
+engine_no_focus_sleep                    : 50       : , "a"            :
+ent_absbox                               : cmd      :                  : Displays the total bounding box for the given entity(s) in green.  Some entites will also display entity specific overlays.  Ar
+ent_attachments                          : cmd      :                  : Displays the attachment points on an entity.  Arguments:    {entity_name} / {class_name} / no argument picks what player is loo
+ent_autoaim                              : cmd      :                  : Displays the entity's autoaim radius.  Arguments:    {entity_name} / {class_name} / no argument picks what player is looking at
+ent_bbox                                 : cmd      :                  : Displays the movement bounding box for the given entity(ies) in orange.  Some entites will also display entity specific overlay
+ent_cancelpendingentfires                : cmd      :                  : Cancels all ent_fire created outputs that are currently waiting for their delay to expire.
+ent_create                               : cmd      :                  : Creates an entity of the given type where the player is looking.
+ent_debugkeys                            : 0        : , "sv"           :
+ent_dump                                 : cmd      :                  : Usage:    ent_dump <entity name>
+ent_fire                                 : cmd      :                  : Usage:    ent_fire <target> [action] [value] [delay]
+ent_info                                 : cmd      :                  : Usage:    ent_info <class name>
+ent_keyvalue                             : cmd      :                  : Applies the comma delimited key=value pairs to the entity with the given Hammer ID.  Format: ent_keyvalue <entity id> <key1>=<v
+ent_list_report                          : cmd      :                  : Reports all list of all entities in a map, one by one
+ent_messages                             : cmd      :                  : Toggles input/output message display for the selected entity(ies).  The name of the entity will be displayed as well as any mes
+ent_messages_draw                        : 0        : , "sv", "cheat"  : Visualizes all entity input/output activity.
+ent_name                                 : cmd      :                  :
+ent_orient                               : cmd      :                  : Orient the specified entity to match the player's angles. By default, only orients target entity's YAW. Use the 'allangles' opt
+ent_pause                                : cmd      :                  : Toggles pausing of input/output message processing for entities.  When turned on processing of all message will stop.  Any mess
+ent_pivot                                : cmd      :                  : Displays the pivot for the given entity(ies).  (y=up=green, z=forward=blue, x=left=red).   Arguments:    {entity_name} / {class
+ent_rbox                                 : cmd      :                  : Displays the total bounding box for the given entity(s) in green.  Some entites will also display entity specific overlays.  Ar
+ent_remove                               : cmd      :                  : Removes the given entity(s)  Arguments:    {entity_name} / {class_name} / no argument picks what player is looking at
+ent_remove_all                           : cmd      :                  : Removes all entities of the specified type  Arguments:    {entity_name} / {class_name}
+ent_rotate                               : cmd      :                  : Rotates an entity by a specified # of degrees
+ent_script_dump                          : cmd      :                  : Dumps the names and values of this entity's script scope to the console  Arguments:    {entity_name} / {class_name} / no argume
+ent_setang                               : cmd      :                  : Set entity angles
+ent_setname                              : cmd      :                  : Sets the targetname of the given entity(s)  Arguments:    {new entity name} {entity_name} / {class_name} / no argument picks wh
+ent_setpos                               : cmd      :                  : Move entity to position
+ent_show_contexts                        : 0        : , "sv"           : Show entity contexts in ent_text display
+ent_show_response_criteria               : cmd      :                  : Print, to the console, an entity's current criteria set used to select responses.  Arguments:    {entity_name} / {class_name} /
+ent_step                                 : cmd      :                  : When 'ent_pause' is set this will step through one waiting input / output message at a time.
+ent_teleport                             : cmd      :                  : Teleport the specified entity to where the player is looking.  Format: ent_teleport <entity name>
+ent_text                                 : cmd      :                  : Displays text debugging information about the given entity(ies) on top of the entity (See Overlay Text)  Arguments:    {entity_
+ent_viewoffset                           : cmd      :                  : Displays the eye position for the given entity(ies) in red.  Arguments:    {entity_name} / {class_name} / no argument picks wha
+exec                                     : cmd      :                  : Execute script file.
+execifexists                             : cmd      :                  : Execute script file if file exists.
+execwithwhitelist                        : cmd      :                  : Execute script file, only execing convars on a whitelist.
+exit                                     : cmd      :                  : Exit the engine.
+explode                                  : cmd      :                  : Kills the player with explosive damage
+explodevector                            : cmd      :                  : Kills a player applying an explosive force. Usage: explodevector <player> <x value> <y value> <z value>
+fadein                                   : cmd      :                  : fadein {time r g b}: Fades the screen in from black or from the specified color over the given number of seconds.
+fadeout                                  : cmd      :                  : fadeout {time r g b}: Fades the screen to black or to the specified color over the given number of seconds.
+fast_poly_convert                        : 1        :                  :
+ff_damage_bullet_penetration             : 0        : , "sv", "rep"    : If friendly fire is off, this will scale the penetration power and damage a bullet does when penetrating another friendly playe
+ff_damage_grenade_hit                    : 1        : , "sv", "rep"    : Enables or disables team damage from thrown grenade impacts
+ff_damage_reduction_bullets              : 0        : , "sv", "rep"    : How much to reduce damage done to teammates when shot.  Range is from 0 - 1 (with 1 being damage equal to what is done to an en
+ff_damage_reduction_grenade              : 0        : , "sv", "rep"    : How much to reduce damage done to teammates by a thrown grenade.  Range is from 0 - 1 (with 1 being damage equal to what is don
+ff_damage_reduction_grenade_self         : 1        : , "sv", "rep"    : How much to damage a player does to himself with his own grenade.  Range is from 0 - 1 (with 1 being damage equal to what is do
+ff_damage_reduction_other                : 0        : , "sv", "rep"    : How much to reduce damage done to teammates by things other than bullets and grenades.  Range is from 0 - 1 (with 1 being damag
+filesystem_buffer_size                   : 0        :                  : Size of per file buffers. 0 for none
+filesystem_max_stdio_read                : 16       :                  :
+filesystem_native                        : 1        :                  : Use native FS or STDIO
+filesystem_report_buffered_io            : 0        :                  :
+filesystem_unbuffered_io                 : 1        :                  :
+find                                     : cmd      :                  : Find concommands with the specified string in their name/help text.
+find_ent                                 : cmd      :                  : Find and list all entities with classnames or targetnames that contain the specified substring. Format: find_ent <substring>
+find_ent_index                           : cmd      :                  : Display data for entity matching specified index. Format: find_ent_index <index>
+findflags                                : cmd      :                  : Find concommands by flags.
+fire_absorbrate                          : 3        : , "sv"           :
+fire_dmgbase                             : 1        : , "sv"           :
+fire_dmginterval                         : 1        : , "sv"           :
+fire_dmgscale                            : 0        : , "sv"           :
+fire_extabsorb                           : 5        : , "sv"           :
+fire_extscale                            : 12       : , "sv"           :
+fire_growthrate                          : 1        : , "sv"           :
+fire_heatscale                           : 1        : , "sv"           :
+fire_incomingheatscale                   : 0        : , "sv"           :
+fire_maxabsorb                           : 50       : , "sv"           :
+firetarget                               : cmd      :                  :
+fish_dormant                             : 0        : , "sv", "cheat", "rep" : Turns off interactive fish behavior. Fish become immobile and unresponsive.
+fish_particles                           : 1        : , "sv"           : Enable particle effects when fish was hit
+flex_expression                          : 0        : , "sv"           :
+flex_looktime                            : 5        : , "sv"           :
+flex_maxawaytime                         : 1        : , "sv"           :
+flex_maxplayertime                       : 7        : , "sv"           :
+flex_minawaytime                         : 0        : , "sv"           :
+flex_minplayertime                       : 5        : , "sv"           :
+flex_talk                                : 0        : , "sv"           :
+flush                                    : cmd      :                  : Flush unlocked cache memory.
+flush_locked                             : cmd      :                  : Flush unlocked and locked cache memory.
+fog_enable_water_fog                     : 1        : , "cheat"        :
+fog_volume_debug                         : 0        : , "sv"           : If enabled, prints diagnostic information about the current fog volume
+forcebind                                : cmd      :                  : Bind a command to an available key. (forcebind command opt:suggestedKey)
+forkandcoredumpchild                     : cmd      :                  : Cause the engine to fork and produce a core dump from within child PID (Debug!!)
+forktest                                 : cmd      :                  : Cause the engine to fork and wait for child PID, parameter can be passed for requested exit code (Debug!!)
+foundry_engine_get_mouse_control         : cmd      :                  : Give the engine control of the mouse.
+foundry_engine_release_mouse_control     : cmd      :                  : Give the control of the mouse back to Hammer.
+foundry_select_entity                    : cmd      :                  : Select the entity under the crosshair or select entities with the specified name.
+foundry_sync_hammer_view                 : cmd      :                  : Move Hammer's 3D view to the same position as the engine's 3D view.
+foundry_update_entity                    : cmd      :                  : Updates the entity's position/angles when in edit mode
+fps_max                                  : 300      : , "a"            : Frame rate limiter
+fps_max_splitscreen                      : 300      :                  : Frame rate limiter, splitscreen
+free_pass_peek_debug                     : 0        : , "sv"           :
+fs_allow_unsafe_writes                   : 0        :                  : 0: Disallow writes to filesystem locations we don't own. 1: Allow such writes (potentially unsafe).
+fs_clear_open_duplicate_times            : cmd      :                  : Clear the list of files that have been opened.
+fs_dump_open_duplicate_times             : cmd      :                  : Set fs_report_long_reads 1 before loading to use this. Prints a list of files that were opened more than once and ~how long was
+fs_fios_cancel_prefetches                : cmd      :                  : Cancels all the prefetches in progress.
+fs_fios_flush_cache                      : cmd      :                  : Flushes the FIOS HDD cache.
+fs_fios_prefetch_file                    : cmd      :                  : Prefetches a file: </PS3_GAME/USRDIR/filename.bin>. The preftech is medium priority and persistent.
+fs_fios_prefetch_file_in_pack            : cmd      :                  : Prefetches a file in a pack: <portal2/models/container_ride/fineDebris_part5.ani>. The preftech is medium priority and non-pers
+fs_fios_print_prefetches                 : cmd      :                  : Displays all the prefetches currently in progress.
+fs_monitor_read_from_pack                : 0        :                  : 0:Off, 1:Any, 2:Sync only
+fs_printopenfiles                        : cmd      :                  : Show all files currently opened by the engine.
+fs_report_long_reads                     : 0        :                  : 0:Off, 1:All (for tracking accumulated duplicate read times), >1:Microsecond threshold
+fs_report_sync_opens                     : 0        :                  : 0:Off, 1:Always, 2:Not during map load
+fs_report_sync_opens_callstack           : 0        :                  : 0 to not display the call-stack when we hit a fs_report_sync_opens warning. Set to 1 to display the call-stack.
+fs_show_pure_state                       : cmd      :                  : Display current filesystem whitelist state
+fs_syncdvddevcache                       : cmd      :                  : Force the 360 to get updated files that are in your p4 changelist(s) from the host PC when running with -dvddev.
+fs_warning_level                         : cmd      :                  : Set the filesystem warning level.
+fs_warning_mode                          : 0        :                  : 0:Off, 1:Warn main thread, 2:Warn other threads
+func_break_max_pieces                    : 15       : , "a", "sv", "rep" :
+func_break_reduction_factor              : 0        : , "sv"           :
+func_breakdmg_bullet                     : 0        : , "sv"           :
+func_breakdmg_club                       : 1        : , "sv"           :
+func_breakdmg_explosive                  : 1        : , "sv"           :
+fx_new_sparks                            : 1        : , "sv", "cheat"  : Use new style sparks.
+g_ai_threadedgraphbuild                  : 0        : , "sv"           : If true, use experimental threaded node graph building.
+g_debug_angularsensor                    : 0        : , "sv", "cheat"  :
+g_debug_constraint_sounds                : 0        : , "sv", "cheat"  : Enable debug printing about constraint sounds.
+g_debug_doors                            : 0        : , "sv"           :
+g_debug_npc_vehicle_roles                : 0        : , "sv"           :
+g_debug_ragdoll_removal                  : 0        : , "sv", "cheat", "rep" :
+g_debug_trackpather                      : 0        : , "sv", "cheat"  :
+g_debug_transitions                      : 0        : , "sv"           : Set to 1 and restart the map to be warned if the map has no trigger_transition volumes. Set to 2 to see a dump of all entities
+g_debug_vehiclebase                      : 0        : , "sv", "cheat"  :
+g_debug_vehicledriver                    : 0        : , "sv", "cheat"  :
+g_debug_vehicleexit                      : 0        : , "sv", "cheat"  :
+g_debug_vehiclesound                     : 0        : , "sv", "cheat"  :
+g_Language                               : 0        : , "sv", "rep"    :
+g_ragdoll_important_maxcount             : 2        : , "sv", "rep"    :
+g_ragdoll_maxcount                       : 8        : , "sv", "rep"    :
+game_mode                                : 0        : , "sv", "rep", "cl" : The current game mode (based on game type). See GameModes.txt or type '[cl/sv]_game_mode_list' in console.
+game_mode_next                           : -1       : , "sv", "rep", "cl" : Set the game mode (based on game type) for next level change. See GameModes.txt or type '[cl/sv]_game_mode_list' in console.
+game_type                                : 0        : , "sv", "rep", "cl" : The current game type. See GameModes.txt or type '[cl/sv]_game_mode_list' in console.
+gamestats_file_output_directory          : 0        : , "sv"           : When -gamestatsfileoutputonly is specified, file will be emitted here instead of to modpath
+give                                     : cmd      :                  : Give item to player.  Arguments: <item_name>
+givecurrentammo                          : cmd      :                  : Give a supply of ammo for current weapon..
+global_chatter_info                      : 0        : , "sv"           : Map/mode-specific responserules criteria used by calls to UTIL_GlobalChatter
+global_event_log_enabled                 : 0        : , "sv", "cheat"  : Enables the global event log system
+global_set                               : cmd      :                  : global_set <globalname> <state>: Sets the state of the given env_global (0 = OFF, 1 = ON, 2 = DEAD).
+god                                      : cmd      :                  : Toggle. Player becomes invulnerable.
+gods                                     : cmd      :                  : Toggle. All players become invulnerable.
+gpu_level                                : 3        :                  : GPU Level - Default: High
+gpu_mem_level                            : 2        :                  : Memory Level - Default: High
+groundlist                               : cmd      :                  : Display ground entity list <index>
+hammer_update_entity                     : cmd      :                  : Updates the entity's position/angles when in edit mode
+hammer_update_safe_entities              : cmd      :                  : Updates entities in the map that can safely be updated (don't have parents or are affected by constraints). Also excludes entit
+help                                     : cmd      :                  : Find help about a convar/concommand.
+hltv_replay_status                       : cmd      :                  : Show Killer Replay status and some statistics, works on listen or dedicated server.
+host_filtered_time_report                : cmd      :                  : Dumps time spent idle in previous frames in ms(dedicated only).
+host_flush_threshold                     : 12       :                  : Memory threshold below which the host should flush caches between server instances
+host_framerate                           : 0        : , "cheat", "rep" : Set to lock per-frame time elapse.
+host_info_show                           : 1        :                  : How server info gets disclosed in server queries: 0 - query disabled, 1 - show only general info, 2 - show full info
+host_limitlocal                          : 0        :                  : Apply cl_cmdrate and cl_updaterate to loopback connection
+host_map                                 : 0        :                  : Current map name.
+host_maplist_recurse_subdirs             : 1        :                  :
+host_name_store                          : 1        :                  : Whether hostname is recorded in game events and GOTV.
+host_players_show                        : 2        :                  : How players are disclosed in server queries: 0 - query disabled, 1 - show only max players count, 2 - show all players
+host_print_frame_times                   : 0        :                  :
+host_profile                             : 0        :                  :
+host_rules_show                          : 1        :                  : How server rules get disclosed in server queries: 0 - query disabled, 1 - query enabled
+host_runframe_input_parcelremainder      : 1        :                  :
+host_runofftime                          : cmd      :                  : Run off some time without rendering/updating sounds
+host_showcachemiss                       : 0        :                  : Print a debug message when the client or server cache is missed.
+host_ShowIPCCallCount                    : 0        :                  : Print # of IPC calls this number of times per second. If set to -1, the # of IPC calls is shown every frame.
+host_sleep                               : 0        : , "cheat"        : Force the host to sleep a certain number of milliseconds each frame.
+host_speeds                              : 0        :                  : Show general system running times.
+host_threaded_sound                      : 1        :                  : Run the sound on a thread (independent of mix)
+host_threaded_sound_simplethread         : 0        :                  : Run the sound on a simple thread not a jobthread
+host_timer_report                        : cmd      :                  : Spew CPU timer jitter for the last 128 frames in microseconds (dedicated only)
+host_timescale                           : 1        : , "cheat", "rep" : Prescale the clock by this amount.
+host_workshop_collection                 : cmd      :                  : Get the latest version of items in a collection and host them on this server.
+host_workshop_map                        : cmd      :                  : Get the latest version of the map and host it on this server.
+hostfile                                 : 0        : , "sv"           : The HOST file to load.
+hostip                                   : 0        :                  : Host game server ip
+hostname                                 : 0        :                  : Hostname for server.
+hostport                                 : 27015    :                  : Host game server port
+hurtme                                   : cmd      :                  : Hurts the player.  Arguments: <health to lose>
+in_forceuser                             : 0        : , "cheat"        : Force user input to this split screen player.
+incrementvar                             : cmd      :                  : Increment specified convar value.
+inferno_child_spawn_interval_multiplier  : 0        : , "sv", "cheat"  : Amount spawn interval increases for each child
+inferno_child_spawn_max_depth            : 4        : , "sv", "rep"    :
+inferno_damage                           : 40       : , "sv", "cheat"  : Damage per second
+inferno_debug                            : 0        : , "sv", "cheat"  :
+inferno_flame_lifetime                   : 7        : , "sv", "rep"    : Average lifetime of each flame in seconds
+inferno_flame_spacing                    : 42       : , "sv", "cheat"  : Minimum distance between separate flame spawns
+inferno_forward_reduction_factor         : 0        : , "sv", "cheat"  :
+inferno_friendly_fire_duration           : 6        : , "sv", "cheat"  : For this long, FF is credited back to the thrower.
+inferno_initial_spawn_interval           : 0        : , "sv", "cheat"  : Time between spawning flames for first fire
+inferno_max_child_spawn_interval         : 0        : , "sv", "cheat"  : Largest time interval for child flame spawning
+inferno_max_flames                       : 16       : , "sv", "rep"    : Maximum number of flames that can be created
+inferno_max_range                        : 150      : , "sv", "rep"    : Maximum distance flames can spread from their initial ignition point
+inferno_max_trace_per_tick               : 16       : , "sv"           :
+inferno_per_flame_spawn_duration         : 3        : , "sv", "cheat"  : Duration each new flame will attempt to spawn new flames
+inferno_scorch_decals                    : 1        : , "sv", "cheat"  :
+inferno_spawn_angle                      : 45       : , "sv", "cheat"  : Angular change from parent
+inferno_surface_offset                   : 20       : , "sv", "cheat"  :
+inferno_velocity_decay_factor            : 0        : , "sv", "cheat"  :
+inferno_velocity_factor                  : 0        : , "sv", "cheat"  :
+inferno_velocity_normal_factor           : 0        : , "sv", "cheat"  :
+ip                                       : 0        :                  : Overrides IP for multihomed hosts
+ip_relay                                 : 0        :                  : Overrides IP used to redirect TV relay connections for NAT hosts
+ip_steam                                 : 0        :                  : Overrides IP used to bind Steam port for multihomed hosts
+ip_tv                                    : 0        :                  : Overrides IP used to bind TV port for multihomed hosts
+ip_tv1                                   : 0        :                  : Overrides IP used to bind TV1 port for multihomed hosts
+kdtree_test                              : cmd      :                  : Tests spatial partition for entities queries.
+key_findbinding                          : cmd      :                  : Find key bound to specified command string.
+key_listboundkeys                        : cmd      :                  : List bound keys with bindings.
+kick                                     : cmd      :                  : Kick a player by name.
+kickid                                   : cmd      :                  : Kick a player by userid or uniqueid, with a message.
+kickid_ex                                : cmd      :                  : Kick a player by userid or uniqueid, provide a force-the-kick flag and also assign a message.
+kill                                     : cmd      :                  : Kills the player with generic damage
+killserver                               : cmd      :                  : Shutdown the server.
+killvector                               : cmd      :                  : Kills a player applying force. Usage: killvector <player> <x value> <y value> <z value>
+listid                                   : cmd      :                  : Lists banned users.
+listip                                   : cmd      :                  : List IP addresses on the ban list.
+listissues                               : cmd      :                  : List all the issues that can be voted on.
+listmodels                               : cmd      :                  : List loaded models.
+listRecentNPCSpeech                      : cmd      :                  : Displays a list of the last 5 lines of speech from NPCs.
+log                                      : cmd      :                  : Enables logging to file, console, and udp < on | off >.
+logaddress_add                           : cmd      :                  : Set address and port for remote host <ip:port>.
+logaddress_add_ex                        : cmd      :                  : Set address and port for remote host <ip:port> and supplies a unique token in the UDP packets.
+logaddress_add_http                      : cmd      :                  : Set URI of a listener to receive logs via http post. Wrap URI in double quotes.
+logaddress_add_http_delayed              : cmd      :                  : Set a delay and URI of a listener to receive logs via http post. Wrap URI in double quotes.
+logaddress_add_ts                        : cmd      :                  : Set address and port for remote host <ip:port> and uses a unique checksum from logaddress_token_secret in the UDP packets.
+logaddress_del                           : cmd      :                  : Remove address and port for remote host <ip:port>.
+logaddress_delall                        : cmd      :                  : Remove all udp addresses being logged to
+logaddress_delall_http                   : cmd      :                  : Remove all http listeners from the dispatch list.
+logaddress_list                          : cmd      :                  : List all addresses currently being used by logaddress.
+logaddress_list_http                     : cmd      :                  : List all URIs currently receiving server logs
+logaddress_token_secret                  : 0        :                  : Set a secret string that will be hashed when using logaddress with explicit token hash.
+loopsingleplayermaps                     : 0        : , "sv", "cheat", "rep" :
+lservercfgfile                           : 0        : , "sv"           :
+map                                      : cmd      :                  : Start playing on specified map.
+map_background                           : cmd      :                  : Runs a map as the background to the main menu.
+map_commentary                           : cmd      :                  : Start playing, with commentary, on a specified map.
+map_noareas                              : 0        :                  : Disable area to area connection testing.
+map_showspawnpoints                      : cmd      :                  : Shows player spawn points (red=invalid). Optionally pass in the duration.
+mapcycledisabled                         : 0        : , "sv", "rep"    : repeats the same map after each match instead of using the map cycle
+mapcyclefile                             : 0        : , "sv"           : Name of the .txt file used to cycle the maps on multiplayer servers
+mapgroup                                 : cmd      :                  : Specify a map group
+maps                                     : cmd      :                  : Displays list of maps.
+mat_aaquality                            : 0        :                  :
+mat_antialias                            : 0        :                  :
+mat_bufferprimitives                     : 0        :                  :
+mat_bumpbasis                            : 0        : , "cheat"        :
+mat_bumpmap                              : 1        :                  :
+mat_compressedtextures                   : 1        :                  :
+mat_configcurrent                        : cmd      :                  : show the current video control panel config for the material system
+mat_custommaterialusage                  : cmd      :                  : Show memory usage for custom weapon materials.
+mat_debugalttab                          : 0        : , "cheat"        :
+mat_debugdepth                           : 0        :                  :
+mat_depthbias_normal                     : 0        : , "cheat"        :
+mat_detail_tex                           : 1        :                  :
+mat_diffuse                              : 1        :                  :
+mat_draw_resolution                      : 0        : , "cheat"        :
+mat_draw_resolution_threshold            : 3072     : , "cheat"        :
+mat_drawflat                             : 0        : , "cheat"        :
+mat_drawgray                             : 0        : , "cheat"        :
+mat_dynamiclightmaps                     : 0        : , "cheat"        :
+mat_dynamicPaintmaps                     : 0        : , "cheat"        :
+mat_envmapsize                           : 128      :                  :
+mat_envmaptgasize                        : 32       :                  :
+mat_exclude_async_update                 : 1        :                  :
+mat_excludetextures                      : 0        :                  :
+mat_fastnobump                           : 0        : , "cheat"        :
+mat_fastspecular                         : 1        :                  : Enable/Disable specularity for visual testing.  Will not reload materials and will not affect perf.
+mat_fillrate                             : 0        : , "cheat"        :
+mat_filterlightmaps                      : 1        :                  :
+mat_filtertextures                       : 1        :                  :
+mat_forceaniso                           : 1        :                  :
+mat_forcedynamic                         : 0        : , "cheat"        :
+mat_forcehardwaresync                    : 0        :                  :
+mat_fullbright                           : 0        : , "cheat"        :
+mat_hdr_enabled                          : cmd      :                  : Report if HDR is enabled for debugging
+mat_info                                 : cmd      :                  : Shows material system info
+mat_levelflush                           : 1        :                  :
+mat_lightmap_pfms                        : 0        :                  : Outputs .pfm files containing lightmap data for each lightmap page when a level exits.
+mat_loadtextures                         : 1        : , "cheat"        :
+mat_luxels                               : 0        : , "cheat"        :
+mat_maxframelatency                      : 1        :                  :
+mat_measurefillrate                      : 0        : , "cheat"        :
+mat_mipmaptextures                       : 1        :                  :
+mat_monitorgamma                         : 2        : , "a"            : monitor gamma (typically 2.2 for CRT and 1.7 for LCD)
+mat_monitorgamma_tv_enabled              : 0        : , "a"            :
+mat_monitorgamma_tv_exp                  : 2        :                  :
+mat_monitorgamma_tv_range_max            : 235      :                  :
+mat_monitorgamma_tv_range_min            : 16       :                  :
+mat_morphstats                           : 0        : , "cheat"        :
+mat_motion_blur_enabled                  : 0        : , "a"            :
+mat_norendering                          : 0        : , "cheat"        :
+mat_normalmaps                           : 0        : , "cheat"        :
+mat_normals                              : 0        : , "cheat"        :
+mat_paint_enabled                        : 0        :                  :
+mat_parallaxmap                          : 1        : , "a"            :
+mat_phong                                : 1        :                  :
+mat_picmip                               : 0        :                  :
+mat_powersavingsmode                     : 0        : , "a"            : Power Savings Mode
+mat_processtoolvars                      : 0        :                  :
+mat_proxy                                : 0        : , "cheat"        :
+mat_queue_mode                           : -1       :                  : The queue/thread mode the material system should use: -1=default, 0=synchronous single thread, 1=queued single thread, 2=queued
+mat_queue_priority                       : 1        :                  :
+mat_queue_report                         : 0        : , "a"            : Report thread stalls.  Positive number will filter by stalls >= time in ms.  -1 reports all locks.
+mat_reducefillrate                       : 0        :                  :
+mat_reduceparticles                      : 0        :                  :
+mat_reloadallcustommaterials             : cmd      :                  : Reloads all custom materials
+mat_reloadallmaterials                   : cmd      :                  : Reloads all materials
+mat_reloadmaterial                       : cmd      :                  : Reloads a single material
+mat_reloadtextures                       : cmd      :                  : Reloads all textures
+mat_report_queue_status                  : 0        :                  :
+mat_reporthwmorphmemory                  : cmd      :                  : Reports the amount of size in bytes taken up by hardware morph textures.
+mat_resolveFullFrameDepth                : 1        : , "cheat"        : Enable depth resolve to a texture. 0=disable, 1=enable via resolve tricks if supported in hw, otherwise disable, 2=force extra
+mat_reversedepth                         : 0        : , "cheat"        :
+mat_savechanges                          : cmd      :                  : saves current video configuration to the registry
+mat_shadowstate                          : 1        :                  :
+mat_showenvmapmask                       : 0        :                  :
+mat_showlowresimage                      : 0        : , "cheat"        :
+mat_showmaterials                        : cmd      :                  : Show materials.
+mat_showmaterialsverbose                 : cmd      :                  : Show materials (verbose version).
+mat_showmiplevels                        : 0        : , "cheat"        : color-code miplevels 2: normalmaps, 1: everything else
+mat_showtextures                         : cmd      :                  : Show used textures.
+mat_software_aa_strength                 : -1       :                  : Software AA - perform a software anti-aliasing post-process (an alternative/supplement to MSAA). This value sets the strength o
+mat_software_occlusion                   : 1        :                  : Occlude renderables by occlusion buffer generated in software
+mat_softwarelighting                     : 0        :                  :
+mat_softwareskin                         : 0        : , "cheat"        :
+mat_specular                             : 1        :                  : Enable/Disable specularity for perf testing.  Will cause a material reload upon change.
+mat_spewalloc                            : 0        : , "a"            :
+mat_tessellation_accgeometrytangents     : 0        : , "cheat"        :
+mat_tessellation_cornertangents          : 1        : , "cheat"        :
+mat_tessellation_update_buffers          : 1        : , "cheat"        :
+mat_texture_tracking                     : 0        :                  :
+mat_texturestreaming                     : 1        : , "a"            : Defer asynchronous loading of high-resolution textures.
+mat_tonemapping_occlusion_use_stencil    : 0        :                  :
+mat_triplebuffered                       : 0        :                  : This means we want triple buffering if we are fullscreen and vsync'd
+mat_verbose_texture_gen                  : 0        :                  :
+mat_vsync                                : 0        :                  : Force sync to vertical retrace
+mat_wireframe                            : 0        : , "cheat"        :
+maxplayers                               : cmd      :                  : Change the maximum number of players allowed on this server.
+mdlcache_dump_dictionary_state           : cmd      :                  : Dump the state of the MDLCache Dictionary.
+mem_compact                              : cmd      :                  :
+mem_dump                                 : cmd      :                  : Dump memory stats to text file.
+mem_dumpstats                            : 0        :                  : Dump current and max heap usage info to console at end of frame ( set to 2 for continuous output )
+mem_eat                                  : cmd      :                  :
+mem_force_flush                          : 0        :                  : Force cache flush of unlocked resources on every alloc
+mem_force_flush_section                  : 0        :                  : Cache section to restrict mem_force_flush
+mem_incremental_compact                  : cmd      :                  :
+mem_incremental_compact_rate             : 0        : , "cheat"        : Rate at which to attempt internal heap compation
+mem_level                                : 2        :                  : Memory Level - Default: High
+mem_max_heapsize                         : 1024     :                  : Maximum amount of memory to dedicate to engine hunk and datacache (in mb)
+mem_max_heapsize_dedicated               : 64       :                  : Maximum amount of memory to dedicate to engine hunk and datacache, for dedicated server (in mb)
+mem_min_heapsize                         : 48       :                  : Minimum amount of memory to dedicate to engine hunk and datacache (in mb)
+mem_periodicdumps                        : 0        :                  : Write periodic memstats dumps every n seconds.
+mem_test                                 : cmd      :                  :
+mem_test_each_frame                      : 0        :                  : Run heap check at end of every frame
+mem_test_every_n_seconds                 : 0        :                  : Run heap check at a specified interval
+mem_test_quiet                           : 0        :                  : Don't print stats when memtesting
+mem_vcollide                             : cmd      :                  : Dumps the memory used by vcollides
+mem_verify                               : cmd      :                  : Verify the validity of the heap
+memory                                   : cmd      :                  : Print memory stats.
+mm_datacenter_debugprint                 : cmd      :                  : Shows information retrieved from data center
+mm_dlc_debugprint                        : cmd      :                  : Shows information about dlc
+mm_server_search_lan_ports               : 27015    : , "a"            : Ports to scan during LAN games discovery. Also used to discover and correctly connect to dedicated LAN servers behind NATs.
+mod_check_vcollide                       : 0        :                  : Check all vcollides on load
+mod_combiner_info                        : cmd      :                  : debug spew for Combiner Info
+mod_dont_load_vertices                   : 1        :                  : For the dedicated server, don't load model vertex data
+mod_DumpWeaponWiewModelCache             : cmd      :                  : Dumps the weapon view model cache contents
+mod_DumpWeaponWorldModelCache            : cmd      :                  : Dumps the weapon world model cache contents
+mod_forcedata                            : 1        :                  : Forces all model file data into cache on model load.
+mod_forcetouchdata                       : 1        :                  : Forces all model file data into cache on model load.
+mod_load_anims_async                     : 0        :                  :
+mod_load_fakestall                       : 0        :                  : Forces all ANI file loading to stall for specified ms
+mod_load_mesh_async                      : 0        :                  :
+mod_load_preload                         : 1        :                  : Indicates how far ahead in seconds to preload animations.
+mod_load_showstall                       : 0        :                  : 1 - show hitches , 2 - show stalls
+mod_load_vcollide_async                  : 0        :                  :
+mod_lock_mdls_on_load                    : 1        :                  :
+mod_lock_meshes_on_load                  : 1        :                  :
+mod_test_mesh_not_available              : 0        :                  :
+mod_test_not_available                   : 0        :                  :
+mod_test_verts_not_available             : 0        :                  :
+mod_touchalldata                         : 1        :                  : Touch model data during level startup
+mod_trace_load                           : 0        :                  :
+mod_WeaponViewModelCache                 : 8        :                  :
+mod_WeaponWorldModelCache                : 10       :                  :
+mod_WeaponWorldModelMinAge               : 3000     :                  :
+molotov_throw_detonate_time              : 2        : , "sv", "rep"    :
+morph_debug                              : 0        :                  :
+morph_path                               : 7        :                  :
+mortar_visualize                         : 0        : , "sv"           :
+motdfile                                 : 0        : , "sv"           : The MOTD file to load.
+mp_allow_parachute                       : 0        : , "sv", "rep"    : Allow to enable parachute.
+mp_allowNPCs                             : 1        : , "sv", "nf"     :
+mp_allowspectators                       : 1        : , "sv", "rep"    : toggles whether the server allows spectator mode or not
+mp_autocrosshair                         : 1        : , "sv", "nf"     :
+mp_autokick                              : 0        : , "sv", "rep"    : Kick idle/team-killing/team-damaging players
+mp_autospec                              : 1        : , "sv"           : Move players to sepctator after 3 minutes of inactivity
+mp_autoteambalance                       : 1        : , "sv", "nf"     :
+mp_autoteambalance_bot                   : 1        : , "sv", "rep"    : Adds a bot to unbalanced team instead of switching players.
+mp_autoteambalance_bot_offline           : 0        : , "sv", "rep"    : Adds a bot to unbalanced team instead of switching players. For offline games only!
+mp_autoteambalancetime                   : 30       : , "sv", "rep"    : Time in seconds before rebalancing teams.
+mp_backup_round_auto                     : 1        : , "sv"           : If enabled will keep in-memory backups to handle reconnecting players even if the backup files aren't written to disk
+mp_backup_round_file                     : 0        : , "sv"           : If set then server will save all played rounds information to files filename_date_time_team1_team2_mapname_roundnum_score1_scor
+mp_backup_round_file_last                : 0        : , "sv"           : Every time a backup file is written the value of this convar gets updated to hold the name of the backup file.
+mp_backup_round_file_pattern             : 0        : , "sv"           : If set then server will save all played rounds information to files named by this pattern, e.g.'%prefix%_%date%_%time%_%team1%_
+mp_bonusroundtime                        : 15       : , "sv", "rep"    : Time after round win until round restarts
+mp_clan_ready_signal                     : 0        : , "sv"           : Text that team leader from each team must speak for the match to begin
+mp_clan_readyrestart                     : 0        : , "sv"           : If non-zero, game will restart once someone from each team gives the ready signal
+mp_competitive_endofmatch_extra_time     : 15       : , "sv"           : After a competitive match finishes rematch voting extra time is given for rankings.
+mp_consecutive_loss_max                  : 4        : , "sv", "rep"    :
+mp_coopmission_bot_difficulty_offset     : 0        : , "sv", "rep"    : The difficulty offset modifier for bots during coop missions.
+mp_coopmission_mission_number            : 0        : , "sv", "rep"    : Which mission the map should run after it loads.
+mp_damage_headshot_only                  : 0        : , "sv", "rep"    : Determines whether non-headshot hits do any damage.
+mp_damage_vampiric_amount                : 0        : , "sv", "rep"    : If Set to non-0, will determine the fraction of damage dealt that will be given to attacker.
+mp_death_drop_grenade                    : 2        : , "sv", "rep"    : Which grenade to drop on player death: 0=none, 1=best, 2=current or best, 3=all grenades
+mp_death_drop_gun                        : 1        : , "sv", "rep"    : Which gun to drop on player death: 0=none, 1=best, 2=current or best
+mp_deathcam_skippable                    : 1        : , "sv", "rep"    : Determines whether a player can early-out of the deathcam.
+mp_defaultteam                           : 0        : , "sv"           :
+mp_disable_appearance_menu               : 0        : , "sv", "rep"    : Allow to disable the Appearance menu.
+mp_disable_autokick                      : cmd      :                  : Prevents a userid from being auto-kicked
+mp_disable_loadout_menu                  : 0        : , "sv", "rep"    : Allow to disable the Loadout menu.
+mp_disable_respawn_times                 : 0        : , "sv", "nf", "rep" :
+mp_disconnect_kills_bots                 : 0        : , "sv"           : When a bot disconnects, kill them first.  Requires mp_disconnect_kills_players.
+mp_disconnect_kills_players              : 1        : , "sv"           : When a player disconnects, kill them first (triggering item drops, stats, etc.)
+mp_display_kill_assists                  : 1        : , "sv", "rep"    : Whether to display and score player assists
+mp_dm_teammode_kill_score                : 1        : , "sv", "rep"    : Team deathmatch victory points to award for enemy kill
+mp_do_warmup_offine                      : 1        : , "sv", "rep"    : Whether or not to do a warmup period at the start of a match in an offline (bot) match.
+mp_do_warmup_period                      : 1        : , "sv", "rep"    : Whether or not to do a warmup period at the start of a match.
+mp_drop_bash                             : 1        : , "sv"           : Enable/Disable the ability to knock weapons away with a bash.
+mp_drop_charge                           : 1        : , "sv"           : Enable/Disable the ability to knock weapons away with a charged attack of the shovel.
+mp_drop_equipment_enable                 : 0        : , "sv"           : Allows players to drop equipment.
+mp_drop_fists                            : 1        : , "sv"           : Enable/Disable the ability to knock weapons away with a charged punch.
+mp_drop_grenade_enable                   : 1        : , "sv"           : Allows players to drop grenades.
+mp_drop_melee_enable                     : 1        : , "sv"           : Allows players to drop knives.
+mp_dump_timers                           : cmd      :                  : Prints round timers to the console for debugging
+mp_enableroundwaittime                   : 1        : , "sv", "rep"    : Enable timers to wait between rounds.
+mp_endmatch_votenextleveltime            : 20       : , "sv", "rep"    : If mp_endmatch_votenextmap is set, players have this much time to vote on the next map at match end.
+mp_endmatch_votenextmap                  : 1        : , "sv", "rep"    : Whether or not players vote for the next map at the end of the match when the final scoreboard comes up
+mp_endmatch_votenextmap_keepcurrent      : 1        : , "sv", "rep"    : If set, keeps the current map in the list of voting options.  If not set, the current map will not appear in the list of voting
+mp_equipment_reset_rounds                : 0        : , "sv", "rep"    : Reset all player equipment every N rounds (0 for never)
+mp_falldamage                            : 0        : , "sv", "nf"     :
+mp_flashlight                            : 1        : , "sv", "nf"     :
+mp_footsteps                             : 1        : , "sv", "nf"     :
+mp_footsteps_serverside                  : 1        : , "sv"           : Makes the server always play footstep sounds. Clients never calculate footstep sounds locally, instead relying on the server.
+mp_force_assign_teams                    : 0        : , "sv", "rep"    : Players don't get to choose what team they are on, it is auto assinged.
+mp_force_deploy_after_death              : 0        : , "sv", "rep"    : Ask player to press Deploy button to respawn.
+mp_force_pick_time                       : 30       : , "sv", "rep"    : The amount of time a player has on the team screen to make a selection before being auto-teamed
+mp_forcecamera                           : 0        : , "sv", "rep"    : Restricts spectator modes for dead players. 0 = Any team. 1 = Only own team. 2 = Any team; fade to black on death. 3 = Only own
+mp_forcerespawn                          : 1        : , "sv", "nf"     :
+mp_forcerespawnplayers                   : cmd      :                  : Force all players to respawn.
+mp_forcewin                              : cmd      :                  : Forces team to win
+mp_fraglimit                             : 0        : , "sv", "nf", "rep" : The number of kills at which the map ends
+mp_freezetime                            : 2        : , "sv", "nf", "rep" : how many seconds to keep players frozen when the round starts
+mp_friendlyfire                          : 0        : , "sv", "nf", "rep" : Allows team members to injure other members of their team
+mp_fun_gamemode_respawn                  : 1        : , "sv", "rep"    : Allow players to respawn in Fun Mode.
+mp_ggprogressive_random_weapon_kills_needed : 2        : , "sv", "rep"    : If mp_ggprogressive_use_random_weapons is set, this is the number of kills needed with each weapon
+mp_ggprogressive_round_restart_delay     : 15       : , "sv", "rep"    : Number of seconds to delay before restarting a round after a win in gungame progessive
+mp_ggprogressive_use_random_weapons      : 1        : , "sv", "rep"    : If set, selects random weapons from set categories for the progression order
+mp_ggtr_always_upgrade                   : 0        : , "sv", "rep"    : Award this many upgrade points every round in demolition mode
+mp_ggtr_bomb_respawn_delay               : 0        : , "sv", "rep"    : Number of seconds to delay before making the bomb available to a respawner in gun game
+mp_ggtr_end_round_kill_bonus             : 1        : , "sv", "rep"    : Number of bonus points awarded in Demolition Mode when knife kill ends round
+mp_ggtr_halftime_delay                   : 0        : , "sv", "rep"    : Number of seconds to delay during TR Mode halftime
+mp_ggtr_last_weapon_kill_ends_half       : 0        : , "sv", "rep"    : End the half and give a team round point when a player makes a kill using the final weapon
+mp_ggtr_num_rounds_autoprogress          : 3        : , "sv", "rep"    : Upgrade the player's weapon after this number of rounds without upgrading
+mp_global_damage_per_second              : 0        : , "sv", "rep"    : If above 0, deal non-lethal damage to players over time.
+mp_godmode                               : 0        : , "sv", "rep"    : Enables server-wide godmode.
+mp_guardian_target_site                  : -1       : , "sv"           : If set to the index of a bombsite, will cause random spawns to be only created near that site.
+mp_halftime                              : 0        : , "sv", "rep"    : Determines whether the match switches sides in a halftime event.
+mp_halftime_duration                     : 15       : , "sv", "rep"    : Number of seconds that halftime lasts
+mp_halftime_pausematch                   : 0        : , "sv", "rep"    : Set to 1 to pause match after halftime countdown elapses. Match must be resumed by vote or admin.
+mp_halftime_pausetimer                   : 0        : , "sv", "rep"    : Set to 1 to stay in halftime indefinitely. Set to 0 to resume the timer.
+mp_halftime_warmuptime                   : 30       : , "sv", "rep"    : How long the warmup period lasts during halftime. Changing this value resets warmup.
+mp_hostages_takedamage                   : 0        : , "sv", "rep"    : Whether or not hostages can be hurt.
+mp_humanteam                             : 0        : , "sv", "rep"    : Restricts human players to a single team {any, US, VC}
+mp_humanteam_limit_class_slots           : 0        : , "sv", "rep"    : Limits class slots on human team to the value of this Cvar
+mp_ignore_round_win_conditions           : 0        : , "sv", "rep"    : Ignore conditions which would end the current round
+mp_join_grace_time                       : 0        : , "sv", "rep"    : Number of seconds after round start to allow a player to join a game
+mp_limit_assault_slots_big               : 99       : , "sv", "rep"    : If player count is bigger than 24 then limit assault slots to this value.
+mp_limit_assault_slots_medium            : 99       : , "sv", "rep"    : If player count is lower than 24 then limit assault slots to this value.
+mp_limit_assault_slots_small             : 99       : , "sv", "rep"    : If player count is lower than 12 then limit assault slots to this value.
+mp_limit_engineer_slots_big              : 3        : , "sv", "rep"    : If player count bigger than 24 then limit engineer slots to this value.
+mp_limit_engineer_slots_medium           : 2        : , "sv", "rep"    : If player count is lower than 24 then limit engineer slots to this value.
+mp_limit_engineer_slots_small            : 1        : , "sv", "rep"    : If player count is lower than 12 then limit engineer slots to this value.
+mp_limit_gunner_slots_big                : 99       : , "sv", "rep"    : If player count is bigger than 24 then limit gunner slots to this value.
+mp_limit_gunner_slots_medium             : 99       : , "sv", "rep"    : If player count is lower than 24 then limit gunner slots to this value.
+mp_limit_gunner_slots_small              : 99       : , "sv", "rep"    : If player count is lower than 12 then limit gunner slots to this value.
+mp_limit_medic_slots_big                 : 99       : , "sv", "rep"    : If player count is bigger than 24 then limit medic slots to this value.
+mp_limit_medic_slots_medium              : 99       : , "sv", "rep"    : If player count is lower than 24 then limit medic slots to this value.
+mp_limit_medic_slots_small               : 99       : , "sv", "rep"    : If player count is lower than 12 then limit medic slots to this value.
+mp_limit_radioman_slots_big              : 2        : , "sv", "rep"    : If player count bigger than 24 then limit radioman slots to this value.
+mp_limit_radioman_slots_medium           : 1        : , "sv", "rep"    : If player count is lower than 24 then limit radioman slots to this value.
+mp_limit_radioman_slots_small            : 1        : , "sv", "rep"    : If player count is lower than 12 then limit radioman slots to this value.
+mp_limit_sniper_slots_big                : 3        : , "sv", "rep"    : If player count is bigger than 24 then limit sniper slots to this value.
+mp_limit_sniper_slots_medium             : 3        : , "sv", "rep"    : If player count is lower than 24 then limit sniper slots to this value.
+mp_limit_sniper_slots_small              : 2        : , "sv", "rep"    : If player count is lower than 12 then limit sniper slots to this value.
+mp_limitteams                            : 0        : , "sv", "nf", "rep" : Max # of players 1 team can have over another
+mp_match_can_clinch                      : 1        : , "sv", "rep"    : Can a team clinch and end the match by being so far ahead that the other team has no way to catching up?
+mp_match_end_changelevel                 : 1        : , "sv", "rep"    : At the end of the match, perform a changelevel even if next map is the same
+mp_match_end_restart                     : 0        : , "sv", "rep"    : At the end of the match, perform a restart instead of loading a new map
+mp_match_restart_delay                   : 43       : , "sv", "rep"    : Time (in seconds) until a match restarts.
+mp_maxrounds                             : 0        : , "sv", "nf", "rep" : max number of rounds to play before server changes maps
+mp_maxrounds_override                    : 0        : , "sv", "rep"    : For offline games, overrides whatever is set in gamemode cfg
+mp_overtime_enable                       : 0        : , "sv", "rep"    : If a match ends in a tie, use overtime rules to determine winner
+mp_overtime_halftime_pausetimer          : 0        : , "sv", "rep"    : If set to 1 will set mp_halftime_pausetimer to 1 before every half of overtime. Set mp_halftime_pausetimer to 0 to resume the t
+mp_overtime_maxrounds                    : 6        : , "sv", "rep"    : When overtime is enabled play additional rounds to determine winner
+mp_pause_match                           : cmd      :                  : Pause the match in the next freeze time
+mp_pickup_allowall                       : 0        : , "sv", "rep"    : Allow to pickup any weapon without limitations, even if voted for.
+mp_pistols_only                          : 0        : , "sv", "rep"    : Players and bots spawn with pistols only.
+mp_playerid                              : 0        : , "sv", "rep"    : Controls what information player see in the status bar: 0 all names; 1 team names; 2 no names
+mp_playerid_delay                        : 0        : , "sv", "rep"    : Number of seconds to delay showing information in the status bar
+mp_playerid_hold                         : 0        : , "sv", "rep"    : Number of seconds to keep showing old information in the status bar
+mp_radar_showall                         : 0        : , "sv", "rep"    : Determines who should see all. 0 = default. 1 = both teams. 2 = Viet Cong. 3 = United States.
+mp_random_class_and_loadout              : 0        : , "sv", "rep"    : Give random loadout and assign random class to player. 1 - do it only on first spawn, 2 - do it on each respawn.
+mp_random_loadout                        : 0        : , "sv", "rep"    : Give random loadout to player. 1 - do it only on first spawn, 2 - do it on each respawn.
+mp_random_weapons                        : 0        : , "sv", "rep"    : Allow to use random weapons.
+mp_randomspawn                           : 0        : , "sv", "rep"    : Enable or disable random spawning points
+mp_randomspawn_dist                      : 0        : , "sv", "rep"    : If using mp_randomspawn, determines whether to test distance when selecting this spot.
+mp_randomspawn_friednly_dist             : 512      : , "sv", "rep"    : If using mp_randomspawn, determines whether to test distance to friendly team members when selecting this spot.
+mp_randomspawn_los                       : 1        : , "sv", "rep"    : If using mp_randomspawn, determines whether to test Line of Sight when spawning.
+mp_require_gun_use_to_acquire            : 0        : , "sv"           : Whether guns must be +used to acquire or default is touch-to-pickup
+mp_respawn_immunitytime                  : 3        : , "sv", "rep"    : How many seconds after respawn immunity lasts.
+mp_respawnwavetime                       : 10       : , "sv", "nf", "rep" : Time between respawn waves.
+mp_respawnwavetime_us                    : 10       : , "sv", "rep"    : Time between respawn waves for United States team.
+mp_respawnwavetime_vc                    : 10       : , "sv", "rep"    : Time between respawn waves for Viet Cong team.
+mp_restartgame                           : 0        : , "sv"           : If non-zero, game will restart in the specified number of seconds
+mp_restartround                          : 0        : , "sv"           : If non-zero, the current round will restart in the specified number of seconds
+mp_round_restart_delay                   : 7        : , "sv", "rep"    : Number of seconds to delay before restarting a round after a win
+mp_roundtime                             : 2        : , "sv", "nf", "rep" : How many minutes each round takes.
+mp_roundtime_defuse                      : 0        : , "sv", "nf", "rep" : How many minutes each round of Bomb Defuse takes. If 0 then use mp_roundtime instead.
+mp_roundtime_deployment                  : 5        : , "sv"           : How many minutes deployment for coop mission takes.
+mp_roundtime_hostage                     : 0        : , "sv", "nf", "rep" : How many minutes each round of Hostage Rescue takes. If 0 then use mp_roundtime instead.
+mp_roundtime_override                    : 0        : , "sv", "rep"    : For offline games, overrides whatever is set in gamemode cfg
+mp_scrambleteams                         : cmd      :                  : Scramble the teams and restart the game
+mp_solid_teammates                       : 0        : , "sv", "rep"    : How solid are teammates: 0 = transparent; 1 = fully solid; 2 = can stand on top of heads
+mp_solid_teammates_pushaway              : 1        : , "sv", "rep"    : Push players away from each other if they are colliding
+mp_spawnprotectiontime                   : 5        : , "sv", "rep"    : Kick players who team-kill within this many seconds of a round restart.
+mp_spec_swapplayersides                  : 0        : , "sv", "rep"    : Toggle set the player names and team names to the opposite side in which they are are on the spectator panel.
+mp_spectators_max                        : 2        : , "sv", "rep"    : How many spectators are allowed in a match.
+mp_stalemate_at_timelimit                : 0        : , "sv", "nf"     : Allow the match to end when mp_timelimit hits instead of waiting for the end of the current round.
+mp_stalemate_enable                      : 0        : , "sv", "nf"     : Enable/Disable stalemate mode.
+mp_stalemate_timelimit                   : 240      : , "sv", "rep"    : Timelimit (in seconds) of the stalemate round.
+mp_starting_losses                       : 0        : , "sv", "rep"    : Determines what the initial loss streak is.
+mp_suicide_time                          : 5        : , "sv", "cheat", "rep" : Specifies number of seconds required to wait before another suicide.
+mp_swapteams                             : cmd      :                  : Swap the teams and restart the game
+mp_switchteams                           : cmd      :                  : Switch teams and restart the game
+mp_tagging_scale                         : 1        : , "sv", "rep"    : Scalar for player tagging modifier when hit. Lower values for greater tagging.
+mp_td_dmgtokick                          : 300      : , "sv", "rep"    : The damage threshhold players have to exceed in a match to get kicked.
+mp_td_dmgtowarn                          : 200      : , "sv", "rep"    : The damage threshhold players have to exceed in a match to get warned that they are about to be kicked.
+mp_td_spawndmgthreshold                  : 50       : , "sv", "rep"    : The damage threshold players have to exceed at the start of the round to be warned/kick.
+mp_teamchange_forbid_time                : 120      : , "sv", "rep"    : Remaining map time in seconds at which team change is not allowed anymore.
+mp_teamflag_1                            : 0        : , "sv"           : Enter a country's alpha 2 code to show that flag next to team 1's name in the spectator scoreboard.
+mp_teamflag_2                            : 0        : , "sv"           : Enter a country's alpha 2 code to show that flag next to team 2's name in the spectator scoreboard.
+mp_teamlist                              : 0        : , "sv", "nf"     :
+mp_teamlogo_1                            : 0        : , "sv"           : Enter a team's shorthand image name to display their logo. Images can be found here: 'resource/flash/econ/tournaments/teams'
+mp_teamlogo_2                            : 0        : , "sv"           : Enter a team's shorthand image name to display their logo. Images can be found here: 'resource/flash/econ/tournaments/teams'
+mp_teammatchstat_1                       : 0        : , "sv"           : A non-empty string sets first team's match stat.
+mp_teammatchstat_2                       : 0        : , "sv"           : A non-empty string sets second team's match stat.
+mp_teammatchstat_cycletime               : 45       : , "sv"           : Cycle match stats after so many seconds
+mp_teammatchstat_holdtime                : 5        : , "sv"           : Decide on a match stat and hold it additionally for at least so many seconds
+mp_teammatchstat_txt                     : 0        : , "sv"           : A non-empty string sets the match stat description, e.g. 'Match 2 of 3'.
+mp_teammates_are_enemies                 : 0        : , "sv", "nf", "rep" : When set, your teammates act as enemies and all players are valid targets.
+mp_teamname_1                            : 0        : , "sv"           : A non-empty string overrides the first team's name.
+mp_teamname_2                            : 0        : , "sv"           : A non-empty string overrides the second team's name.
+mp_teamoverride                          : 1        : , "sv"           :
+mp_teamplay                              : 0        : , "sv", "nf"     :
+mp_teamprediction_pct                    : 0        : , "sv"           : A value between 1 and 99 will show predictions in favor of CT team.
+mp_teamprediction_txt                    : 0        : , "sv"           : A value between 1 and 99 will set predictions in favor of first team.
+mp_teams_unbalance_limit                 : 1        : , "sv", "nf", "rep" : Teams are unbalanced when one team has this many more players than the other team. (0 disables check)
+mp_teamscore_1                           : 0        : , "sv"           : A non-empty string for best-of-N maps won by the first team.
+mp_teamscore_2                           : 0        : , "sv"           : A non-empty string for best-of-N maps won by the second team.
+mp_timelimit                             : 15       : , "sv", "nf", "rep" : game time per map in minutes
+mp_tkpunish                              : 0        : , "sv", "rep"    : Will TK'ers and team damagers be punished in the next round?  {0=no,  1=yes}
+mp_tournament                            : 0        : , "sv", "nf", "rep" :
+mp_tournament_restart                    : cmd      :                  : Restart Tournament Mode on the current level.
+mp_unlimitedrounds                       : 0        : , "sv", "rep"    : Indicates that gamemode wants to have unlimited rounds.
+mp_unpause_match                         : cmd      :                  : Resume the match
+mp_use_respawn_waves                     : 0        : , "sv", "rep"    : When set to 1, and that player's team is set to respawn, they will respawn in waves. If set to 2, respawn wave will start once
+mp_use_special_loadout                   : 0        : , "sv", "rep"    : Allow to use special loadout.
+mp_verbose_changelevel_spew              : 1        : , "sv", "rep"    :
+mp_waitingforplayers_cancel              : 0        : , "sv"           : Set to 1 to end the WaitingForPlayers period.
+mp_waitingforplayers_restart             : 0        : , "sv"           : Set to 1 to start or restart the WaitingForPlayers period.
+mp_waitingforplayers_time                : 0        : , "sv"           : WaitingForPlayers time length in seconds
+mp_warmup_end                            : cmd      :                  : End warmup immediately.
+mp_warmup_pausetimer                     : 0        : , "sv", "rep"    : Set to 1 to stay in warmup indefinitely. Set to 0 to resume the timer.
+mp_warmup_start                          : cmd      :                  : Start warmup.
+mp_warmuptime                            : 60       : , "sv", "rep"    : How long the warmup period lasts. Changing this value resets warmup.
+mp_warmuptime_all_players_connected      : 0        : , "sv", "rep"    : Warmup time to use when all players have connected. 0 to disable.
+mp_weapon_allow_multiple_of_type         : 0        : , "sv", "rep"    : 1 - Allow players to have multiple weapons of the same type . 2 - Players are not allowed to have multiple of the same non-gren
+mp_weapon_firstdraw                      : 1        : , "sv", "rep"    : 0 - no first draw animation, 1 - play first draw on spawn, 2 play first draw whenever gun is deployed for the first time.
+mp_weapon_melee_touch_time_after_hit     : 0        : , "sv", "cheat"  :
+mp_weapon_next_owner_touch_time          : 1        : , "sv", "cheat"  :
+mp_weapon_prev_owner_touch_time          : 1        : , "sv", "cheat"  :
+mp_weapon_self_inflict_amount            : 0        : , "sv", "rep"    : If Set to non-0, will hurt the attacker by the specified fraction of max damage if they miss.
+mp_weapons_allow_map_placed              : 0        : , "sv", "rep"    : If this convar is set, when a match starts, the game will not delete weapons placed in the map.
+mp_weapons_allow_typecount               : 5        : , "sv", "rep"    : Determines how many purchases of each weapon type allowed per player per round (0 to disallow purchasing, -1 to have no limit).
+mp_weapons_glow_on_ground                : 0        : , "sv", "rep"    : If this convar is set, weapons on the ground will have a glow around them.
+mp_weaponstay                            : 0        : , "sv", "nf"     :
+mp_win_panel_display_time                : 5        : , "sv", "rep"    : The amount of time to show the win panel between matches / halfs
+mp_winlimit                              : 0        : , "sv", "nf", "rep" : Max score one team can reach before server changes maps
+mp_zombie_shop_menu_anywhere             : 0        : , "sv", "rep"    : Allow to enable shop menu anywhere in Zombie Mode.
+multvar                                  : cmd      :                  : Multiply specified convar value.
+mutechatbyid                             : cmd      :                  : Mute text input of a player by userid.
+mutevoicebyid                            : cmd      :                  : Mute voice of a player by userid.
+name                                     : 0        : , "a", "user", "print", "server_can_execute", "ss" : Current user name
+nav_add_to_selected_set                  : cmd      :                  : Add current area to the selected set.
+nav_add_to_selected_set_by_id            : cmd      :                  : Add specified area id to the selected set.
+nav_analyze                              : cmd      :                  : Re-analyze the current Navigation Mesh and save it to disk.
+nav_approach_points_area_size_threshold  : 200      : , "sv"           : Ignore nav areas with at least one side smaller than this amount during approach point calculation.
+nav_area_bgcolor                         : 503316480 : , "sv", "cheat"  : RGBA color to draw as the background color for nav areas while editing.
+nav_area_max_size                        : 50       : , "sv", "cheat"  : Max area size created in nav generation
+nav_avoid                                : cmd      :                  : Toggles the 'avoid this area when possible' flag used by the AI system.
+nav_begin_area                           : cmd      :                  : Defines a corner of a new Area or Ladder. To complete the Area or Ladder, drag the opposite corner to the desired location and
+nav_begin_deselecting                    : cmd      :                  : Start continuously removing from the selected set.
+nav_begin_drag_deselecting               : cmd      :                  : Start dragging a selection area.
+nav_begin_drag_selecting                 : cmd      :                  : Start dragging a selection area.
+nav_begin_selecting                      : cmd      :                  : Start continuously adding to the selected set.
+nav_begin_shift_xy                       : cmd      :                  : Begin shifting the Selected Set.
+nav_build_ladder                         : cmd      :                  : Attempts to build a nav ladder on the climbable surface under the cursor.
+nav_check_connectivity                   : cmd      :                  : Checks to be sure every (or just the marked) nav area can get to every goal area for the map (hostages or bomb site).
+nav_check_file_consistency               : cmd      :                  : Scans the maps directory and reports any missing/out-of-date navigation files.
+nav_check_floor                          : cmd      :                  : Updates the blocked/unblocked status for every nav area.
+nav_check_stairs                         : cmd      :                  : Update the nav mesh STAIRS attribute
+nav_chop_selected                        : cmd      :                  : Chops all selected areas into their component 1x1 areas
+nav_clear_attribute                      : cmd      :                  : Remove given nav attribute from all areas in the selected set.
+nav_clear_selected_set                   : cmd      :                  : Clear the selected set.
+nav_clear_walkable_marks                 : cmd      :                  : Erase any previously placed walkable positions.
+nav_compress_id                          : cmd      :                  : Re-orders area and ladder ID's so they are continuous.
+nav_connect                              : cmd      :                  : To connect two Areas, mark the first Area, highlight the second Area, then invoke the connect command. Note that this creates a
+nav_coplanar_slope_limit                 : 0        : , "sv", "cheat"  :
+nav_coplanar_slope_limit_displacement    : 0        : , "sv", "cheat"  :
+nav_corner_adjust_adjacent               : 18       : , "sv", "cheat"  : radius used to raise/lower corners in nearby areas when raising/lowering corners.
+nav_corner_lower                         : cmd      :                  : Lower the selected corner of the currently marked Area.
+nav_corner_place_on_ground               : cmd      :                  : Places the selected corner of the currently marked Area on the ground.
+nav_corner_raise                         : cmd      :                  : Raise the selected corner of the currently marked Area.
+nav_corner_select                        : cmd      :                  : Select a corner of the currently marked Area. Use multiple times to access all four corners.
+nav_create_area_at_feet                  : 0        : , "sv", "cheat"  : Anchor nav_begin_area Z to editing player's feet
+nav_create_place_on_ground               : 0        : , "sv", "cheat"  : If true, nav areas will be placed flush with the ground when created by hand.
+nav_crouch                               : cmd      :                  : Toggles the 'must crouch in this area' flag used by the AI system.
+nav_debug_blocked                        : 0        : , "sv", "cheat"  :
+nav_delete                               : cmd      :                  : Deletes the currently highlighted Area.
+nav_delete_marked                        : cmd      :                  : Deletes the currently marked Area (if any).
+nav_disconnect                           : cmd      :                  : To disconnect two Areas, mark an Area, highlight a second Area, then invoke the disconnect command. This will remove all connec
+nav_displacement_test                    : 10000    : , "sv", "cheat"  : Checks for nodes embedded in displacements (useful for in-development maps)
+nav_dont_hide                            : cmd      :                  : Toggles the 'area is not suitable for hiding spots' flag used by the AI system.
+nav_drag_selection_volume_zmax_offset    : 32       : , "sv", "rep"    : The offset of the nav drag volume top from center
+nav_drag_selection_volume_zmin_offset    : 32       : , "sv", "rep"    : The offset of the nav drag volume bottom from center
+nav_draw_limit                           : 500      : , "sv", "cheat"  : The maximum number of areas to draw in edit mode
+nav_edit                                 : 0        : , "sv", "cheat"  : Set to one to interactively edit the Navigation Mesh. Set to zero to leave edit mode.
+nav_end_area                             : cmd      :                  : Defines the second corner of a new Area or Ladder and creates it.
+nav_end_deselecting                      : cmd      :                  : Stop continuously removing from the selected set.
+nav_end_drag_deselecting                 : cmd      :                  : Stop dragging a selection area.
+nav_end_drag_selecting                   : cmd      :                  : Stop dragging a selection area.
+nav_end_selecting                        : cmd      :                  : Stop continuously adding to the selected set.
+nav_end_shift_xy                         : cmd      :                  : Finish shifting the Selected Set.
+nav_flood_select                         : cmd      :                  : Selects the current Area and all Areas connected to it, recursively. To clear a selection, use this command again.
+nav_gen_cliffs_approx                    : cmd      :                  : Mark cliff areas, post-processing approximation
+nav_generate                             : cmd      :                  : Generate a Navigation Mesh for the current map and save it to disk.
+nav_generate_fencetops                   : 1        : , "sv", "cheat"  : Autogenerate nav areas on fence and obstacle tops
+nav_generate_fixup_jump_areas            : 1        : , "sv", "cheat"  : Convert obsolete jump areas into 2-way connections
+nav_generate_incremental                 : cmd      :                  : Generate a Navigation Mesh for the current map and save it to disk.
+nav_generate_incremental_range           : 2000     : , "sv", "cheat"  :
+nav_generate_incremental_tolerance       : 0        : , "sv", "cheat"  : Z tolerance for adding new nav areas.
+nav_generate_threaded                    : 1        : , "sv", "cheat"  :
+nav_jump                                 : cmd      :                  : Toggles the 'traverse this area by jumping' flag used by the AI system.
+nav_ladder_flip                          : cmd      :                  : Flips the selected ladder's direction.
+nav_load                                 : cmd      :                  : Loads the Navigation Mesh for the current map.
+nav_lower_drag_volume_max                : cmd      :                  : Lower the top of the drag select volume.
+nav_lower_drag_volume_min                : cmd      :                  : Lower the bottom of the drag select volume.
+nav_make_sniper_spots                    : cmd      :                  : Chops the marked area into disconnected sub-areas suitable for sniper spots.
+nav_mark                                 : cmd      :                  : Marks the Area or Ladder under the cursor for manipulation by subsequent editing commands.
+nav_mark_attribute                       : cmd      :                  : Set nav attribute for all areas in the selected set.
+nav_mark_unnamed                         : cmd      :                  : Mark an Area with no Place name. Useful for finding stray areas missed when Place Painting.
+nav_mark_walkable                        : cmd      :                  : Mark the current location as a walkable position. These positions are used as seed locations when sampling the map to generate
+nav_max_view_distance                    : 0        : , "sv", "cheat"  : Maximum range for precomputed nav mesh visibility (0 = default 1500 units)
+nav_max_vis_delta_list_length            : 64       : , "sv", "cheat"  :
+nav_merge                                : cmd      :                  : To merge two Areas into one, mark the first Area, highlight the second by pointing your cursor at it, and invoke the merge comm
+nav_merge_mesh                           : cmd      :                  : Merges a saved selected set into the current mesh.
+nav_no_hostages                          : cmd      :                  : Toggles the 'hostages cannot use this area' flag used by the AI system.
+nav_no_jump                              : cmd      :                  : Toggles the 'dont jump in this area' flag used by the AI system.
+nav_place_floodfill                      : cmd      :                  : Sets the Place of the Area under the cursor to the curent Place, and 'flood-fills' the Place to all adjacent Areas. Flood-filli
+nav_place_list                           : cmd      :                  : Lists all place names used in the map.
+nav_place_pick                           : cmd      :                  : Sets the current Place to the Place of the Area under the cursor.
+nav_place_replace                        : cmd      :                  : Replaces all instances of the first place with the second place.
+nav_place_set                            : cmd      :                  : Sets the Place of all selected areas to the current Place.
+nav_potentially_visible_dot_tolerance    : 0        : , "sv", "cheat"  :
+nav_precise                              : cmd      :                  : Toggles the 'dont avoid obstacles' flag used by the AI system.
+nav_prone                                : cmd      :                  : Toggles the 'must prone in this area' flag used by the AI system.
+nav_props_walkthrough                    : 0        : , "sv", "cheat"  : Should it be possible to walk through props?
+nav_quicksave                            : 0        : , "sv", "cheat"  : Set to one to skip the time consuming phases of the analysis.  Useful for data collection and testing.
+nav_raise_drag_volume_max                : cmd      :                  : Raise the top of the drag select volume.
+nav_raise_drag_volume_min                : cmd      :                  : Raise the bottom of the drag select volume.
+nav_recall_selected_set                  : cmd      :                  : Re-selects the stored selected set.
+nav_remove_from_selected_set             : cmd      :                  : Remove current area from the selected set.
+nav_remove_jump_areas                    : cmd      :                  : Removes legacy jump areas, replacing them with connections.
+nav_restart_after_analysis               : 1        : , "sv"           : When nav nav_restart_after_analysis finishes, restart the server.  Turning this off can cause crashes, but is useful for increm
+nav_run                                  : cmd      :                  : Toggles the 'traverse this area by running' flag used by the AI system.
+nav_save                                 : cmd      :                  : Saves the current Navigation Mesh to disk.
+nav_save_selected                        : cmd      :                  : Writes the selected set to disk for merging into another mesh via nav_merge_mesh.
+nav_select_blocked_areas                 : cmd      :                  : Adds all blocked areas to the selected set
+nav_select_damaging_areas                : cmd      :                  : Adds all damaging areas to the selected set
+nav_select_half_space                    : cmd      :                  : Selects any areas that intersect the given half-space.
+nav_select_invalid_areas                 : cmd      :                  : Adds all invalid areas to the Selected Set.
+nav_select_obstructed_areas              : cmd      :                  : Adds all obstructed areas to the selected set
+nav_select_overlapping                   : cmd      :                  : Selects nav areas that are overlapping others.
+nav_select_radius                        : cmd      :                  : Adds all areas in a radius to the selection set
+nav_select_stairs                        : cmd      :                  : Adds all stairway areas to the selected set
+nav_selected_set_border_color            : -16751516 : , "sv", "cheat"  : Color used to draw the selected set borders while editing.
+nav_selected_set_color                   : 1623785472.000 : , "sv", "cheat"  : Color used to draw the selected set background while editing.
+nav_set_place_mode                       : cmd      :                  : Sets the editor into or out of Place mode. Place mode allows labelling of Area with Place names.
+nav_shift                                : cmd      :                  : Shifts the selected areas by the specified amount
+nav_show_approach_points                 : 0        : , "sv", "cheat"  : Show Approach Points in the Navigation Mesh.
+nav_show_area_info                       : 0        : , "sv", "cheat"  : Duration in seconds to show nav area ID and attributes while editing
+nav_show_compass                         : 0        : , "sv", "cheat"  :
+nav_show_continguous                     : 0        : , "sv", "cheat"  : Highlight non-contiguous connections
+nav_show_danger                          : 0        : , "sv", "cheat"  : Show current 'danger' levels.
+nav_show_light_intensity                 : 0        : , "sv", "cheat"  :
+nav_show_node_grid                       : 0        : , "sv", "cheat"  :
+nav_show_node_id                         : 0        : , "sv", "cheat"  :
+nav_show_nodes                           : 0        : , "sv", "cheat"  :
+nav_show_player_counts                   : 0        : , "sv", "cheat"  : Show current player counts in each area.
+nav_show_potentially_visible             : 0        : , "sv", "cheat"  : Show areas that are potentially visible from the current nav area
+nav_simplify_selected                    : cmd      :                  : Chops all selected areas into their component 1x1 areas and re-merges them together into larger areas
+nav_slope_limit                          : 0        : , "sv", "cheat"  : The ground unit normal's Z component must be greater than this for nav areas to be generated.
+nav_slope_tolerance                      : 0        : , "sv", "cheat"  : The ground unit normal's Z component must be this close to the nav area's Z component to be generated.
+nav_snap_to_grid                         : 0        : , "sv", "cheat"  : Snap to the nav generation grid when creating new nav areas
+nav_solid_props                          : 0        : , "sv", "cheat"  : Make props solid to nav generation/editing
+nav_solid_props_filter                   : 0        : , "sv", "cheat"  : Filter out everything that does not match specified name.
+nav_splice                               : cmd      :                  : To splice, mark an area, highlight a second area, then invoke the splice command to create a new, connected area between them.
+nav_split                                : cmd      :                  : To split an Area into two, align the split line using your cursor and invoke the split command.
+nav_split_place_on_ground                : 0        : , "sv", "cheat"  : If true, nav areas will be placed flush with the ground when split.
+nav_stand                                : cmd      :                  : Toggles the 'stand while hiding' flag used by the AI system.
+nav_stop                                 : cmd      :                  : Toggles the 'must stop when entering this area' flag used by the AI system.
+nav_store_selected_set                   : cmd      :                  : Stores the current selected set for later retrieval.
+nav_strip                                : cmd      :                  : Strips all Hiding Spots, Approach Points, and Encounter Spots from the current Area.
+nav_subdivide                            : cmd      :                  : Subdivides all selected areas.
+nav_test_node                            : 0        : , "sv", "cheat"  :
+nav_test_node_crouch                     : 0        : , "sv", "cheat"  :
+nav_test_node_crouch_dir                 : 4        : , "sv", "cheat"  :
+nav_test_node_prone                      : 0        : , "sv", "cheat"  :
+nav_test_stairs                          : cmd      :                  : Test the selected set for being on stairs
+nav_toggle_deselecting                   : cmd      :                  : Start or stop continuously removing from the selected set.
+nav_toggle_in_selected_set               : cmd      :                  : Remove current area from the selected set.
+nav_toggle_place_mode                    : cmd      :                  : Toggle the editor into and out of Place mode. Place mode allows labelling of Area with Place names.
+nav_toggle_place_painting                : cmd      :                  : Toggles Place Painting mode. When Place Painting, pointing at an Area will 'paint' it with the current Place.
+nav_toggle_selected_set                  : cmd      :                  : Toggles all areas into/out of the selected set.
+nav_toggle_selecting                     : cmd      :                  : Start or stop continuously adding to the selected set.
+nav_transient                            : cmd      :                  : Toggles the 'area is transient and may become blocked' flag used by the AI system.
+nav_unmark                               : cmd      :                  : Clears the marked Area or Ladder.
+nav_update_blocked                       : cmd      :                  : Updates the blocked/unblocked status for every nav area.
+nav_update_lighting                      : cmd      :                  : Recomputes lighting values
+nav_update_visibility_on_edit            : 0        : , "sv", "cheat"  : If nonzero editing the mesh will incrementally recompue visibility
+nav_use_place                            : cmd      :                  : If used without arguments, all available Places will be listed. If a Place argument is given, the current Place is set.
+nav_walk                                 : cmd      :                  : Toggles the 'traverse this area by walking' flag used by the AI system.
+nav_warp_to_mark                         : cmd      :                  : Warps the player to the marked area.
+nav_world_center                         : cmd      :                  : Centers the nav mesh in the world
+nb_allow_avoiding                        : 1        : , "sv", "cheat"  :
+nb_allow_climbing                        : 1        : , "sv", "cheat"  :
+nb_allow_gap_jumping                     : 1        : , "sv", "cheat"  :
+nb_blind                                 : 0        : , "sv", "cheat"  : Disable vision
+nb_command                               : cmd      :                  : Sends a command string to all bots
+nb_debug                                 : cmd      :                  : Debug NextBots.  Categories are: BEHAVIOR, LOOK_AT, PATH, ANIMATION, LOCOMOTION, VISION, HEARING, EVENTS, ERRORS.
+nb_debug_climbing                        : 0        : , "sv", "cheat"  :
+nb_debug_filter                          : cmd      :                  : Add items to the NextBot debug filter. Items can be entindexes or part of the indentifier of one or more bots.
+nb_debug_history                         : 1        : , "sv", "cheat"  : If true, each bot keeps a history of debug output in memory
+nb_debug_known_entities                  : 0        : , "sv", "cheat"  : Show the 'known entities' for the bot that is the current spectator target
+nb_delete_all                            : cmd      :                  : Delete all non-player NextBot entities.
+nb_force_look_at                         : cmd      :                  : Force selected bot to look at the local player's position
+nb_goal_look_ahead_range                 : 50       : , "sv", "cheat"  :
+nb_head_aim_resettle_angle               : 100      : , "sv", "cheat"  : After rotating through this angle, the bot pauses to 'recenter' its virtual mouse on its virtual mousepad
+nb_head_aim_resettle_time                : 0        : , "sv", "cheat"  : How long the bot pauses to 'recenter' its virtual mouse on its virtual mousepad
+nb_head_aim_settle_duration              : 0        : , "sv", "cheat"  :
+nb_head_aim_steady_max_rate              : 100      : , "sv", "cheat"  :
+nb_ladder_align_range                    : 50       : , "sv", "cheat"  :
+nb_move_to_cursor                        : cmd      :                  : Tell all NextBots to move to the cursor position
+nb_path_draw_inc                         : 100      : , "sv", "cheat"  :
+nb_path_draw_segment_count               : 100      : , "sv", "cheat"  :
+nb_path_segment_influence_radius         : 100      : , "sv", "cheat"  :
+nb_player_crouch                         : 0        : , "sv", "cheat"  : Force bots to crouch
+nb_player_move                           : 1        : , "sv", "cheat"  : Prevents bots from moving
+nb_player_move_direct                    : 0        : , "sv"           :
+nb_player_stop                           : 0        : , "sv", "cheat"  : Stop all NextBotPlayers from updating
+nb_player_walk                           : 0        : , "sv", "cheat"  : Force bots to walk
+nb_saccade_speed                         : 1000     : , "sv", "cheat"  :
+nb_saccade_time                          : 0        : , "sv", "cheat"  :
+nb_select                                : cmd      :                  : Select the bot you are aiming at for further debug operations.
+nb_speed_look_ahead_range                : 150      : , "sv", "cheat"  :
+nb_stop                                  : 0        : , "sv", "cheat", "rep" : Stop all NextBots
+nb_update_debug                          : 0        : , "sv", "cheat"  :
+nb_update_framelimit                     : 15       : , "sv", "cheat"  :
+nb_update_frequency                      : 0        : , "sv", "cheat"  :
+nb_update_maxslide                       : 2        : , "sv", "cheat"  :
+nb_warp_selected_here                    : cmd      :                  : Teleport the selected bot to your cursor position
+net_allow_multicast                      : 1        : , "a"            :
+net_blockmsg                             : 0        : , "cheat"        : Discards incoming message: <0|1|name>
+net_chan_limit_msec                      : 0        :                  : Netchannel processing is limited to so many milliseconds, abort connection if exceeding budget
+net_chan_stats_dump                      : 0        :                  : Netchannel statistics will dump in the logs upon request
+net_chan_stats_dump_top_msgs             : 5        :                  : Netchannel statistics will dump so many top messages in each category
+net_chan_stats_lru                       : 3        :                  : Netchannel statistics LRU accumulation buffer size
+net_channels                             : cmd      :                  : Shows net channel info
+net_compressvoice                        : 0        :                  : Attempt to compress out of band voice payloads (360 only).
+net_drawslider                           : 0        :                  : Draw completion slider during signon
+net_droponsendoverflow                   : 0        :                  : If enabled, channel will drop client when sending too much data causes buffer overrun
+net_droppackets                          : 0        : , "cheat"        : Drops next n packets on client
+net_dumpeventstats                       : cmd      :                  : Dumps out a report of game event network usage
+net_dumptest                             : 0        :                  :
+net_fakejitter                           : 0        : , "cheat"        : Jitter fakelag packet time
+net_fakelag                              : 0        : , "cheat"        : Lag all incoming network data (including loopback) by this many milliseconds.
+net_fakeloss                             : 0        : , "cheat"        : Simulate packet loss as a percentage (negative means drop 1/n packets)
+net_maxcleartime                         : 4        :                  : Max # of seconds we can wait for next packets to be sent based on rate setting (0 == no limit).
+net_maxfilesize                          : 64       :                  : Maximum allowed file size for uploading in MB
+net_maxfragments                         : 1200     :                  : Max fragment bytes per packet
+net_maxroutable                          : 1200     : , "a", "user"    : Requested max packet size before packets are 'split'.
+net_paranoid                             : 1        :                  :
+net_public_adr                           : 0        :                  : For servers behind NAT/DHCP meant to be exposed to the public internet, this is the public facing ip address string: ('x.x.x.x'
+net_queue_trace                          : 0        :                  :
+net_showeventlisteners                   : 0        :                  : Show listening addition/removals
+net_showevents                           : 0        :                  : Dump game events to console (1=client only, 2=all).
+net_showfragments                        : 0        :                  : Show netchannel fragments
+net_showpeaks                            : 0        :                  : Show messages for large packets only: <size>
+net_showreliablesounds                   : 0        : , "cheat"        :
+net_showsplits                           : 0        :                  : Show info about packet splits
+net_showtcp                              : 0        :                  : Dump TCP stream summary to console
+net_showudp                              : 0        :                  : Dump UDP packets summary to console
+net_showudp_oob                          : 0        :                  : Dump OOB UDP packets summary to console
+net_showudp_remoteonly                   : 0        :                  : Dump non-loopback udp only
+net_splitrate                            : 1        :                  : Number of fragments for a splitpacket that can be sent per frame
+net_start                                : cmd      :                  : Inits multiplayer network sockets
+net_status                               : cmd      :                  : Shows current network status
+net_steamcnx_status                      : cmd      :                  : Print status of steam connection sockets.
+net_threaded_socket_burst_cap            : 256      :                  : Max number of packets per burst beyond which threaded socket pump algorithm will start dropping packets.
+net_threaded_socket_recovery_rate        : 6400     :                  : Number of packets per second that threaded socket pump algorithm allows from client.
+net_threaded_socket_recovery_time        : 60       :                  : Number of seconds over which the threaded socket pump algorithm will fully recover client ratelimit.
+net_usesocketsforloopback                : 0        :                  : Use network sockets layer even for listen server local player's packets (multiplayer only).
+net_warningthrottle                      : 5        :                  : Network warning throttling to specified Hz rate
+next                                     : 0        : , "cheat"        : Set to 1 to advance to next frame ( when singlestep == 1 )
+nextlevel                                : 0        : , "sv", "nf", "rep" : If set to a valid map name, will change to this map during the next changelevel
+nextmap_print_enabled                    : 0        : , "sv"           : When enabled prints next map to clients
+nextmode                                 : 0        : , "sv", "nf", "rep" : Sets the game mode to be played when the next level loads
+noclip                                   : cmd      :                  : Toggle. Player becomes non-solid and flies.  Optional argument of 0 or 1 to force enable/disable
+noclip_fixup                             : 1        : , "sv", "cheat"  :
+notarget                                 : cmd      :                  : Toggle. Player becomes hidden to NPCs.
+npc_ally_deathmessage                    : 1        : , "sv", "cheat"  :
+npc_ammo_deplete                         : cmd      :                  : Subtracts half of the target's ammo
+npc_bipass                               : cmd      :                  : Displays the local movement attempts by the given NPC(s) (triangulation detours).  Failed bypass routes are displayed in red, s
+npc_combat                               : cmd      :                  : Displays text debugging information about the squad and enemy of the selected NPC  (See Overlay Text)  Arguments:    {npc_name}
+npc_conditions                           : cmd      :                  : Displays all the current AI conditions that an NPC has in the overlay text.  Arguments:    {npc_name} / {npc class_name} / no a
+npc_create                               : cmd      :                  : Creates an NPC of the given type where the player is looking (if the given NPC can actually stand at that location).    Argumen
+npc_create_aimed                         : cmd      :                  : Creates an NPC aimed away from the player of the given type where the player is looking (if the given NPC can actually stand at
+npc_create_equipment                     : 0        : , "sv"           :
+npc_destroy                              : cmd      :                  : Removes the given NPC(s) from the universe Arguments:    {npc_name} / {npc_class_name} / no argument picks what player is looki
+npc_destroy_unselected                   : cmd      :                  : Removes all NPCs from the universe that aren't currently selected
+npc_enemies                              : cmd      :                  : Shows memory of NPC.  Draws an X on top of each memory.  Eluded entities drawn in blue (don't know where it went)  Unreachable
+npc_focus                                : cmd      :                  : Displays red line to NPC's enemy (if has one) and blue line to NPC's target entity (if has one)  Arguments:    {npc_name} / {np
+npc_freeze                               : cmd      :                  : Selected NPC(s) will freeze in place (or unfreeze). If there are no selected NPCs, uses the NPC under the crosshair.  Arguments
+npc_freeze_unselected                    : cmd      :                  : Freeze all NPCs not selected
+npc_go                                   : cmd      :                  : Selected NPC(s) will go to the location that the player is looking (shown with a purple box)  Arguments: -none-
+npc_go_do_run                            : 1        : , "sv"           : Set whether should run on NPC go
+npc_go_random                            : cmd      :                  : Sends all selected NPC(s) to a random node.  Arguments:    -none-
+npc_heal                                 : cmd      :                  : Heals the target back to full health
+npc_height_adjust                        : 1        : , "a", "sv"      : Enable test mode for ik height adjustment
+npc_kill                                 : cmd      :                  : Kills the given NPC(s) Arguments:    {npc_name} / {npc_class_name} / no argument picks what player is looking at
+npc_nearest                              : cmd      :                  : Draw's a while box around the NPC(s) nearest node  Arguments:    {entity_name} / {class_name} / no argument picks what player i
+npc_relationships                        : cmd      :                  : Displays the relationships between this NPC and all others.  Arguments:    {entity_name} / {class_name} / no argument picks wha
+npc_reset                                : cmd      :                  : Reloads schedules for all NPC's from their script files  Arguments: -none-
+npc_route                                : cmd      :                  : Displays the current route of the given NPC as a line on the screen.  Waypoints along the route are drawn as small cyan rectang
+npc_select                               : cmd      :                  : Select or deselects the given NPC(s) for later manipulation.  Selected NPC's are shown surrounded by a red translucent box  Arg
+npc_sentences                            : 0        : , "sv"           :
+npc_set_freeze                           : cmd      :                  : Selected NPC(s) will freeze in place (or unfreeze). If there are no selected NPCs, uses the NPC under the crosshair.  Arguments
+npc_set_freeze_unselected                : cmd      :                  : Freeze all NPCs not selected
+npc_speakall                             : cmd      :                  : Force the npc to try and speak all their responses
+npc_squads                               : cmd      :                  : Obsolete.  Replaced by npc_combat
+npc_steering                             : cmd      :                  : Displays the steering obstructions of the NPC (used to perform local avoidance)  Arguments:    {entity_name} / {class_name} / n
+npc_steering_all                         : cmd      :                  : Displays the steering obstructions of all NPCs (used to perform local avoidance)
+npc_task_text                            : cmd      :                  : Outputs text debugging information to the console about the all the tasks + break conditions of the selected NPC current schedu
+npc_tasks                                : cmd      :                  : Displays detailed text debugging information about the all the tasks of the selected NPC current schedule (See Overlay Text)  A
+npc_teleport                             : cmd      :                  : Selected NPC will teleport to the location that the player is looking (shown with a purple box)  Arguments: -none-
+npc_thinknow                             : cmd      :                  : Trigger NPC to think
+npc_viewcone                             : cmd      :                  : Displays the viewcone of the NPC (where they are currently looking and what the extents of there vision is)  Arguments:    {ent
+npc_vphysics                             : 0        : , "sv"           :
+observer_use                             : cmd      :                  :
+occlusion_old                            : 0        :                  :
+occlusion_stats                          : cmd      :                  : Occlusion statistics; [-jitter] [-reset]
+occlusion_test_async                     : 0        :                  : Enable asynchronous occlusion test in another thread; may save some server tick time at the cost of synchronization overhead wi
+occlusion_test_async_jitter              : 2        : , "cheat"        :
+occlusion_test_async_move_tolerance      : 8        : , "cheat"        :
+occlusion_test_camera_margins            : 12       : , "sv"           : Amount by which the camera (viewer's eye) is expanded for occlusion test. This should be large enough to accommodate eye's move
+occlusion_test_jump_margin               : 12       :                  : Amount by which the player bounding box is expanded up for occlusion test to account for jumping. This margin should be large e
+occlusion_test_margins                   : 36       :                  : Amount by which the player bounding box is expanded for occlusion test. This margin should be large enough to accommodate playe
+occlusion_test_shadow_length             : 144      : , "sv"           : Max length of completely occluded shadow to consider a player for occlusion test. If shadow provably stops at this distance, th
+occlusion_test_shadow_max_distance       : 1500     :                  : Max distance at which to consider shadows for occlusion computations
+old_radiusdamage                         : 0        : , "sv", "rep"    :
+paintsplat_bias                          : 0        : , "cheat", "rep" : Change bias value for computing circle buffer
+paintsplat_max_alpha_noise               : 0        : , "cheat", "rep" : Max noise value of circle alpha
+paintsplat_noise_enabled                 : 1        : , "cheat", "rep" :
+parachute                                : cmd      :                  : equips parachute
+particle_test_attach_attachment          : 0        : , "sv", "cheat"  : Attachment index for attachment mode
+particle_test_attach_mode                : 0        : , "sv", "cheat"  : Possible Values: 'start_at_attachment', 'follow_attachment', 'start_at_origin', 'follow_origin'
+particle_test_file                       : 0        : , "sv", "cheat"  : Name of the particle system to dynamically spawn
+particle_test_start                      : cmd      :                  : Dispatches the test particle system with the parameters specified in particle_test_file,  particle_test_attach_mode and particl
+particle_test_stop                       : cmd      :                  : Stops all particle systems on the selected entities.  Arguments:    {entity_name} / {class_name} / no argument picks what playe
+password                                 : 0        : , "a", "norecord" : Current server access password
+path                                     : cmd      :                  : Show the engine filesystem path.
+pause                                    : cmd      :                  : Toggle the server pause state.
+phosphorus_grenade_bounce                : 2        : , "sv", "rep"    :
+phosphorus_grenade_damage                : 85       : , "sv", "rep"    :
+phosphorus_grenade_gravity               : 700      : , "sv", "rep"    :
+phosphorus_grenade_velocity              : 500      : , "sv", "rep"    :
+phys_debug_check_contacts                : 0        : , "sv", "cheat", "rep" :
+phys_enable_query_cache                  : 1        :                  :
+phys_explosionscale                      : 2        : , "sv", "rep"    : Modifier for explosion impulse hits on players
+phys_headshotscale                       : 1        : , "sv", "rep"    : Modifier for the headshot impulse hits on players
+phys_impactforcescale                    : 1        : , "sv"           :
+phys_penetration_error_time              : 10       : , "sv"           : Controls the duration of vphysics penetration error boxes.
+phys_playerscale                         : 1        : , "sv", "rep"    : This multiplies the bullet impact impuse on players for more dramatic results when players are shot.
+phys_pushscale                           : 1        : , "sv", "rep"    :
+phys_show_active                         : 0        : , "sv", "cheat"  :
+phys_speeds                              : 0        : , "sv"           :
+phys_stressbodyweights                   : 5        : , "sv"           :
+phys_timescale                           : 1        : , "sv"           : Scale time for physics
+phys_upimpactforcescale                  : 0        : , "sv"           :
+physics_budget                           : cmd      :                  : Times the cost of each active object
+physics_constraints                      : cmd      :                  : Highlights constraint system graph for an entity
+physics_debug_entity                     : cmd      :                  : Dumps debug info for an entity
+physics_highlight_active                 : cmd      :                  : Turns on the absbox for all active physics objects
+physics_report_active                    : cmd      :                  : Lists all active physics objects
+physics_select                           : cmd      :                  : Dumps debug info for an entity
+physicsshadowupdate_render               : 0        : , "sv"           :
+PhysPMC                                  : 0        :                  :
+picker                                   : cmd      :                  : Toggles 'picker' mode.  When picker is on, the bounding box, pivot and debugging text is displayed for whatever entity the play
+ping                                     : cmd      :                  : Display ping to server.
+pipeline_static_props                    : 1        :                  :
+player_debug_print_damage                : 0        : , "sv", "cheat"  : When true, print amount and type of all damage received by player to console.
+player_old_armor                         : 0        : , "sv"           :
+plugin_load                              : cmd      :                  : plugin_load <filename> : loads a plugin
+plugin_pause                             : cmd      :                  : plugin_pause <index> : pauses a loaded plugin
+plugin_pause_all                         : cmd      :                  : pauses all loaded plugins
+plugin_print                             : cmd      :                  : Prints details about loaded plugins
+plugin_unload                            : cmd      :                  : plugin_unload <index> : unloads a plugin
+plugin_unpause                           : cmd      :                  : plugin_unpause <index> : unpauses a disabled plugin
+plugin_unpause_all                       : cmd      :                  : unpauses all disabled plugins
+print_mapgroup_sv                        : cmd      :                  : Prints the current mapgroup and the contained maps
+prop_active_gib_limit                    : 64       : , "sv"           :
+prop_active_gib_max_fade_time            : 12       : , "sv"           :
+prop_barbwire_damage_per_second          : 3        : , "sv"           :
+prop_barbwire_speed_scale                : 0        : , "sv"           :
+prop_break_disable_float                 : 0        : , "sv"           :
+prop_crosshair                           : cmd      :                  : Shows name for prop looking at
+prop_debug                               : cmd      :                  : Toggle prop debug mode. If on, props will show colorcoded bounding boxes. Red means ignore all damage. White means respond phys
+prop_dynamic_create                      : cmd      :                  : Creates a dynamic prop with a specific .mdl aimed away from where the player is looking.  Arguments: {.mdl name}
+prop_physics_create                      : cmd      :                  : Creates a physics prop with a specific .mdl aimed away from where the player is looking.  Arguments: {.mdl name}
+props_break_max_pieces                   : -1       : , "sv", "rep"    : Maximum prop breakable piece count (-1 = model default)
+props_break_max_pieces_perframe          : -1       : , "sv", "rep"    : Maximum prop breakable piece count per frame (-1 = model default)
+pvs_min_player_distance                  : 1500     : , "sv"           : Min distance to player at which PVS is used. At closer distances, PVS assumes we can see a shadow or something else from the pl
+quit                                     : cmd      :                  : Exit the engine.
+r_AirboatViewDampenDamp                  : 1        : , "sv", "cheat", "nf", "rep" :
+r_AirboatViewDampenFreq                  : 7        : , "sv", "cheat", "nf", "rep" :
+r_AirboatViewZHeight                     : 0        : , "sv", "cheat", "nf", "rep" :
+r_ambientboost                           : 1        :                  : Set to boost ambient term if it is totally swamped by local lights
+r_ambientfactor                          : 5        :                  : Boost ambient cube by no more than this factor
+r_ambientfraction                        : 0        : , "cheat"        : Fraction of direct lighting used to boost lighting when model requests
+r_ambientmin                             : 0        :                  : Threshold above which ambient cube will not boost (i.e. it's already sufficiently bright
+r_colorbrushes                           : 0        : , "cheat"        :
+r_colordisps                             : 0        : , "cheat"        :
+r_colorstaticprops                       : 0        : , "cheat"        :
+r_csm_static_vb                          : 1        :                  : Use a precomputed static VB for CSM rendering
+r_debugrandomstaticlighting              : 0        : , "cheat"        : Set to 1 to randomize static lighting for debugging.  Must restart for change to take affect.
+r_decal_cover_count                      : 4        :                  :
+r_decal_overlap_area                     : 0        :                  :
+r_decal_overlap_count                    : 3        :                  :
+r_decals                                 : 2048     :                  :
+r_decalstaticprops                       : 1        :                  : Decal static props test
+r_disable_static_prop_loading            : 0        : , "cheat"        : If non-zero when a map loads, static props won't be loaded
+r_DispBuildable                          : 0        : , "cheat"        :
+r_DispWalkable                           : 0        : , "cheat"        :
+r_drawbatchdecals                        : 1        :                  : Render decals batched.
+r_drawbrushmodels                        : 1        : , "cheat"        : Render brush models. 0=Off, 1=Normal, 2=Wireframe
+r_drawdecals                             : 1        : , "cheat"        : Render decals.
+r_DrawDisp                               : 1        : , "cheat"        : Toggles rendering of displacment maps
+r_drawentities                           : 1        : , "cheat"        :
+r_drawfuncdetail                         : 1        : , "cheat"        : Render func_detail
+r_drawleaf                               : -1       : , "cheat"        : Draw the specified leaf.
+r_drawlightcache                         : 0        : , "cheat"        : 0: off 1: draw light cache entries 2: draw rays
+r_drawmodeldecals                        : 1        :                  :
+r_DrawModelLightOrigin                   : 0        : , "cheat"        :
+r_drawmodelstatsoverlay                  : 0        : , "cheat"        :
+r_drawmodelstatsoverlaydistance          : 500      : , "cheat"        :
+r_drawmodelstatsoverlayfilter            : -1       : , "cheat"        :
+r_drawmodelstatsoverlaymax               : 1        : , "a"            : time in milliseconds beyond which a model overlay is fully red in r_drawmodelstatsoverlay 2
+r_drawmodelstatsoverlaymin               : 0        : , "a"            : time in milliseconds that a model must take to render before showing an overlay in r_drawmodelstatsoverlay 2
+r_drawstaticprops                        : 1        : , "cheat"        : 0=Off, 1=Normal, 2=Wireframe
+r_drawtranslucentworld                   : 1        : , "cheat"        :
+r_drawworld                              : 1        : , "cheat"        : Render the world.
+r_dscale_basefov                         : 90       : , "cheat"        :
+r_dscale_fardist                         : 2000     : , "cheat"        :
+r_dscale_farscale                        : 4        : , "cheat"        :
+r_dscale_neardist                        : 100      : , "cheat"        :
+r_dscale_nearscale                       : 1        : , "cheat"        :
+r_dynamic                                : 1        :                  :
+r_eyeglintlodpixels                      : 20       :                  : The number of pixels wide an eyeball has to be before rendering an eyeglint.  Is a floating point value.
+r_eyemove                                : 1        : , "a"            :
+r_eyes                                   : 1        :                  :
+r_eyeshift_x                             : 0        : , "a"            :
+r_eyeshift_y                             : 0        : , "a"            :
+r_eyeshift_z                             : 0        : , "a"            :
+r_eyesize                                : 0        : , "a"            :
+r_fastzreject                            : 0        :                  : Activate/deactivates a fast z-setting algorithm to take advantage of hardware with fast z reject. Use -1 to default to hardware
+r_fastzrejectdisp                        : 0        :                  : Activates/deactivates fast z rejection on displacements (360 only). Only active when r_fastzreject is on.
+r_flashlightdepthtexture                 : 1        :                  :
+r_flashlightscissor                      : 0        :                  :
+r_flex                                   : 1        :                  :
+r_flushlod                               : cmd      :                  : Flush and reload LODs.
+r_ForceRestore                           : 0        :                  :
+r_glint_alwaysdraw                       : 0        :                  :
+r_glint_procedural                       : 0        :                  :
+r_hidepaintedsurfaces                    : 0        :                  : If enabled, hides all surfaces which have been painted.
+r_hunkalloclightmaps                     : 1        :                  :
+r_hwmorph                                : 0        : , "cheat"        :
+r_itemblinkbrightness                    : 3        : , "cheat"        :
+r_itemblinkmax                           : 1        : , "cheat"        :
+r_itemblinkrate                          : 4        : , "cheat"        :
+r_JeepFOV                                : 90       : , "sv", "cheat", "rep" :
+r_JeepViewDampenDamp                     : 1        : , "sv", "cheat", "nf", "rep" :
+r_JeepViewDampenFreq                     : 7        : , "sv", "cheat", "nf", "rep" :
+r_JeepViewZHeight                        : 10       : , "sv", "cheat", "nf", "rep" :
+r_keepstyledlightmapsonly                : 0        :                  :
+r_lightaverage                           : 1        :                  : Activates/deactivate light averaging
+r_lightcachemodel                        : -1       : , "cheat"        :
+r_lightinterp                            : 5        : , "cheat"        : Controls the speed of light interpolation, 0 turns off interpolation
+r_lightmap                               : -1       : , "cheat"        :
+r_lightstyle                             : -1       : , "cheat"        :
+r_lockpvs                                : 0        : , "cheat"        : Lock the PVS so you can fly around and inspect what is being drawn.
+r_lod                                    : -1       :                  :
+r_maxmodeldecal                          : 50       :                  :
+r_modelAmbientMin                        : 0        : , "cheat"        : Minimum value for the ambient lighting on dynamic models with more than one bone (like players and their guns).
+r_modelwireframedecal                    : 0        : , "cheat"        :
+r_nohw                                   : 0        : , "cheat"        :
+r_norefresh                              : 0        :                  :
+r_nosw                                   : 0        : , "cheat"        :
+r_novis                                  : 0        : , "cheat"        : Turn off the PVS.
+r_occludeemaxarea                        : 0        :                  : Prevents occlusion testing for entities that take up more than X% of the screen. 0 means use whatever the level said to use.
+r_occluderminarea                        : 0        :                  : Prevents this occluder from being used if it takes up less than X% of the screen. 0 means use whatever the level said to use.
+r_occludermincount                       : 0        :                  : At least this many occluders will be used, no matter how big they are.
+r_occluders_cull_disp                    : 0        : , "cheat"        : Do early-out occlusion culling while rendering disps
+r_occluders_cull_leaf                    : 0        : , "cheat"        : Do early-out occlusion culling while traversing leaves
+r_occluders_detail                       : 1        : , "cheat"        : Render func_detail world triangles for occlusion culling
+r_occluders_disp                         : 1        : , "cheat"        : Render displacement triangles for occlusion culling
+r_occluders_max_height                   : 128      :                  : Maximum height of occluder buffer
+r_occluders_max_width                    : 256      :                  : Maximum width of occluder buffer
+r_occluders_sort                         : 1        : , "cheat"        : Sort occluder triangles in front-to-back order
+r_occluders_sort_visualize               : 0        : , "cheat"        : Visualize sort order of occluder surfaces
+r_occluders_threaded                     : 0        :                  : Enable threaded occluder rendering
+r_occluders_world                        : 1        : , "cheat"        : Render world triangles for occlusion culling
+r_occlusion                              : 0        :                  : Activate/deactivate the occlusion system.
+r_occlusionspew                          : 0        : , "cheat"        : Activate/deactivates spew about what the occlusion system is doing.
+r_partition_level                        : -1       : , "cheat"        : Displays a particular level of the spatial partition system. Use -1 to disable it.
+r_portal_use_pvs_optimization            : 0        :                  : Enables an optimization that allows portals to be culled when outside of the PVS.
+r_printdecalinfo                         : cmd      :                  :
+r_proplightingfromdisk                   : 1        :                  : 0=Off, 1=On, 2=Show Errors
+r_proplightingpooling                    : -1       : , "cheat"        : 0 - off, 1 - static prop color meshes are allocated from a single shared vertex buffer (on hardware that supports stream offset
+r_randomflex                             : 0        : , "cheat"        :
+r_rootlod                                : 0        :                  : Root LOD
+r_shadow_deferred                        : 0        : , "cheat"        : Toggle deferred shadow rendering
+r_shadowrendertotexture                  : 0        :                  :
+r_showenvcubemap                         : 0        : , "cheat"        :
+r_skin                                   : 0        : , "cheat"        :
+r_skybox_draw_last                       : 0        :                  : Draws skybox after world brush geometry, rather than before.
+r_slowpathwireframe                      : 0        : , "cheat"        :
+r_staticpropinfo                         : 0        : , "cheat"        :
+r_teeth                                  : 1        :                  :
+r_unloadlightmaps                        : 0        :                  :
+r_vehicleBrakeRate                       : 1        : , "sv", "cheat"  :
+r_VehicleViewDampen                      : 1        : , "sv", "cheat", "nf", "rep" :
+r_visocclusion                           : 0        : , "cheat"        : Activate/deactivate wireframe rendering of what the occlusion system is doing.
+r_visualizetraces                        : 0        : , "sv", "cheat"  :
+radarvisdistance                         : 1000     : , "sv", "cheat"  : at this distance and beyond you need to be point right at someone to see them
+radarvismaxdot                           : 0        : , "sv", "cheat"  : how closely you have to point at someone to see them beyond max distance
+radarvismethod                           : 1        : , "sv", "cheat"  : 0 for traditional method, 1 for more realistic method
+radarvispow                              : 0        : , "sv", "cheat"  : the degree to which you can point away from a target, and still see them on radar.
+rcon_connected_clients_allow             : 1        : , "rep"          : Allow clients to use rcon commands on server.
+rcon_password                            : 0        : , "norecord"     : remote console password.
+recompute_speed                          : cmd      :                  : Recomputes clock speed (for debugging purposes).
+reload                                   : cmd      :                  : Reload the most recent saved game (add setpos to jump to current view position on reload).
+removeallids                             : cmd      :                  : Remove all user IDs from the ban list.
+removeid                                 : cmd      :                  : Remove a user ID from the ban list.
+removeip                                 : cmd      :                  : Remove an IP address from the ban list.
+replay_debug                             : 0        : , "rep"          :
+report_entities                          : cmd      :                  : Lists all entities
+report_simthinklist                      : cmd      :                  : Lists all simulating/thinking entities
+report_soundpatch                        : cmd      :                  : reports sound patch count
+report_touchlinks                        : cmd      :                  : Lists all touchlinks
+res_restrict_access                      : 0        :                  :
+reset_expo                               : cmd      :                  : Reset player scores, player controls, team scores, and end the round
+reset_gameconvars                        : cmd      :                  : Reset a bunch of game convars to default values
+respawn_entities                         : cmd      :                  : Respawn all the entities in the map.
+restart                                  : cmd      :                  : Restart the game on the same level (add setpos to jump to current view position on restart).
+restrict_assault                         : 0        : , "sv", "rep"    : Server owner may allow or disallow Assault class
+restrict_engineer                        : 0        : , "sv", "rep"    : Server owner may allow or disallow Engineer class
+restrict_flamethrower                    : 0        : , "sv", "rep"    : Server owner may allow or disallow flamethrowers
+restrict_grenade                         : 0        : , "sv", "rep"    : Server owner may allow or disallow grenades
+restrict_grenadelauncher                 : 0        : , "sv", "rep"    : Server owner may allow or disallow grenade launchers
+restrict_grenadespecial                  : 0        : , "sv", "rep"    : Server owner may allow or disallow molotov or gas grenade
+restrict_gunner                          : 0        : , "sv", "rep"    : Server owner may allow or disallow Gunner class
+restrict_medic                           : 0        : , "sv", "rep"    : Server owner may allow or disallow Medic class
+restrict_mine                            : 0        : , "sv", "rep"    : Server owner may allow or disallow mines
+restrict_radioman                        : 0        : , "sv", "rep"    : Server owner may allow or disallow Radioman class
+restrict_riflegrenade                    : 0        : , "sv", "rep"    : Server owner may allow or disallow rifle grenades
+restrict_rocketlauncher                  : 0        : , "sv", "rep"    : Server owner may allow or disallow rocket launchers
+restrict_smoke                           : 0        : , "sv", "rep"    : Server owner may allow or disallow smoke grenades
+restrict_sniper                          : 0        : , "sv", "rep"    : Server owner may allow or disallow Sniper class
+rr_debug_qa                              : 0        : , "sv"           : Set to 1 to see debug related to the Question & Answer system used to create conversations between allied NPCs.
+rr_debugresponseconcept                  : 0        : , "sv"           : If set, rr_debugresponses will print only responses testing for the specified concept
+rr_debugresponses                        : 0        : , "sv"           : Show verbose matching output (1 for simple, 2 for rule scoring, 3 for noisy). If set to 4, it will only show response success/f
+rr_debugrule                             : 0        : , "sv"           : If set to the name of the rule, that rule's score will be shown whenever a concept is passed into the response rules system.
+rr_dumpresponses                         : 0        : , "sv"           : Dump all response_rules.txt and rules (requires restart)
+rr_followup_maxdist                      : 1800     : , "sv", "cheat"  : 'then ANY' or 'then ALL' response followups will be dispatched only to characters within this distance.
+rr_forceconcept                          : cmd      :                  : fire a response concept directly at a given character. USAGE: rr_forceconcept <target> <concept> 'criteria1:value1,criteria2:va
+rr_reloadresponsesystems                 : cmd      :                  : Reload all response system scripts.
+rr_remarkable_max_distance               : 1200     : , "sv", "cheat"  : AIs will not even consider remarkarbles that are more than this many units away.
+rr_remarkable_world_entities_replay_limit : 1        : , "sv", "cheat"  : TLK_REMARKs will be dispatched no more than this many times for any given info_remarkable
+rr_remarkables_enabled                   : 0        : , "sv", "cheat"  : If 1, polling for info_remarkables and issuances of TLK_REMARK is enabled.
+rr_thenany_score_slop                    : 0        : , "sv", "cheat"  : When computing respondents for a 'THEN ANY' rule, all rule-matching scores within this much of the best score will be considere
+say                                      : cmd      :                  : Display player message
+say_team                                 : cmd      :                  : Display player message to team
+scene_async_prefetch_spew                : 0        : , "sv"           : Display async .ani file loading info.
+scene_clamplookat                        : 1        : , "sv"           : Clamp head turns to a MAX of 20 degrees per think.
+scene_clientflex                         : 1        : , "sv", "rep"    : Do client side flex animation.
+scene_clientplayback                     : 1        : , "sv"           : Play all vcds on the clients.
+scene_flatturn                           : 1        : , "sv"           :
+scene_flush                              : cmd      :                  : Flush all .vcds from the cache and reload from disk.
+scene_forcecombined                      : 0        : , "sv"           : When playing back, force use of combined .wav files even in english.
+scene_maxcaptionradius                   : 1200     : , "sv"           : Only show closed captions if recipient is within this many units of speaking actor (0==disabled).
+scene_playvcd                            : cmd      :                  : Play the given VCD as an instanced scripted scene.
+scene_print                              : 0        : , "sv", "rep"    : When playing back a scene, print timing and event info to console.
+scene_showfaceto                         : 0        : , "a", "sv"      : When playing back, show the directions of faceto events.
+scene_showlook                           : 0        : , "a", "sv"      : When playing back, show the directions of look events.
+scene_showmoveto                         : 0        : , "a", "sv"      : When moving, show the end location.
+scene_showunlock                         : 0        : , "a", "sv"      : Show when a vcd is playing but normal AI is running.
+score_blind_enemy_bonus                  : 10       : , "sv"           : Bonus for blinding enemy players
+score_blind_friendly_penalty             : 10       : , "sv"           : Penalty for blinding friendly players
+score_damage                             : 1        : , "sv"           : Points awarded for each point of damage to an enemy
+score_default                            : 0        : , "sv"           : Default points for a new user
+score_ff_damage                          : 1        : , "sv"           : Penalty awarded for each point of damage to a teammate
+score_heal_player                        : 100      : , "sv"           : amount of score added for healing someone
+score_heal_player_thrown                 : 100      : , "sv"           : amount of score added if someone used your thrown medicbox
+score_kill_enemy_bonus                   : 100      : , "sv"           : Points awarded for killing an enemy
+score_kill_enemy_bonus_headshot          : 25       : , "sv"           : Points awarded for headshotting an enemy
+score_player_assist                      : 50       : , "sv"           : amount of score added for an assist
+score_player_conquest_capture            : 250      : , "sv"           : amount of score added for capturing conquest flag
+score_player_conquest_neutralize         : 200      : , "sv"           : amount of score added for neutralizing conquest flag
+score_player_ctf_capture                 : 300      : , "sv"           : amount of score added for capturing CTF flag
+score_player_ctf_pickup                  : 100      : , "sv"           : amount of score added for picking up dropped CTF flag
+score_player_ctf_return                  : 100      : , "sv"           : amount of score added for returning CTF flag of friendly team
+score_player_ctf_take                    : 150      : , "sv"           : amount of score added for taking CTF flag
+score_player_defuse_demolition           : 250      : , "sv"           : amount of score for defusing a bomb in demolition
+score_player_draw                        : 250      : , "sv"           : amount of score for draw
+score_player_draw_tdm                    : 150      : , "sv"           : amount of score for TDM draw
+score_player_explode_demolition          : 350      : , "sv"           : amount of score for successfully exploding a bomb in demolition
+score_player_kc_pickup                   : 100      : , "sv"           : amount of score added for picking up dropped KC enemy dogtag
+score_player_kc_return                   : 100      : , "sv"           : amount of score added for returning KC dogtag of friendly team
+score_player_lose_conquest               : 500      : , "sv"           : amount of score for Conquest loosers
+score_player_lose_ctf                    : 500      : , "sv"           : amount of score for CTF loosers
+score_player_lose_demolition             : 500      : , "sv"           : amount of score for Demolition loosers
+score_player_lose_tdm                    : 250      : , "sv"           : amount of score for TDM loosers
+score_player_ob_pickup                   : 100      : , "sv"           : amount of score added for picking up dropped Oddball
+score_player_plant_demolition            : 250      : , "sv"           : amount of score for planting a bomb in demolition
+score_player_win_conquest                : 3000     : , "sv"           : amount of score for Conquest winners
+score_player_win_ctf                     : 2000     : , "sv"           : amount of score for CTF winners
+score_player_win_demolition              : 3000     : , "sv"           : amount of score for Demolition winners
+score_player_win_lms                     : 500      : , "sv"           : amount of score for winner in Last Man Standing
+score_player_win_tdm                     : 500      : , "sv"           : amount of score for TDM winners
+score_refill_player                      : 100      : , "sv"           : amount of score added for refilling someones ammo
+score_refill_player_thrown               : 100      : , "sv"           : amount of score added if someone used your thrown ammobox
+score_team_damage_bonus                  : 1        : , "sv"           : Points awarded for each point of damage a nearby (in same zone) teammate does to enemies
+score_teamwork_airstrike                 : 100      : , "sv"           : amount of score added for calling an airstrike on marked position
+score_teamwork_capture                   : 75       : , "sv"           : amount of score added for capturing flags together
+score_teamwork_refill                    : 25       : , "sv"           : amount of score added for refilling or healing a player who asked for help
+score_typical_good_score                 : 5        : , "sv"           : An average good score for use in funfacts
+script                                   : cmd      :                  : Run the text as a script
+script_connect_debugger_on_mapspawn      : 0        : , "sv"           :
+script_debug                             : cmd      :                  : Connect the vscript VM to the script debugger
+script_dump_all                          : cmd      :                  : Dump the state of the VM to the console
+script_execute                           : cmd      :                  : Run a vscript file
+script_help                              : cmd      :                  : Output help for script functions, optionally with a search string
+script_reload_code                       : cmd      :                  : Execute a vscript file, replacing existing functions with the functions in the run script
+script_reload_entity_code                : cmd      :                  : Execute all of this entity's VScripts, replacing existing functions with the functions in the run scripts
+script_reload_think                      : cmd      :                  : Execute an activation script, replacing existing functions with the functions in the run script
+sdr_spew_level                           : 3        :                  : verbosity level for SteamNetSockets spew
+server_game_time                         : cmd      :                  : Gives the game time in seconds (server's curtime)
+servercfgfile                            : 0        : , "sv"           :
+setang                                   : cmd      :                  : Snap player eyes to specified pitch yaw <roll:optional> (must have sv_cheats).
+setang_exact                             : cmd      :                  : Snap player eyes and orientation to specified pitch yaw <roll:optional> (must have sv_cheats).
+setmodel                                 : cmd      :                  : Changes's player's model
+setpause                                 : cmd      :                  : Set the pause state of the server.
+setpos                                   : cmd      :                  : Move player to specified origin (must have sv_cheats).
+setpos_exact                             : cmd      :                  : Move player to an exact specified origin (must have sv_cheats).
+setpos_player                            : cmd      :                  : Move specified player to specified origin (must have sv_cheats).
+shake                                    : cmd      :                  : Shake the screen.
+showhitlocation                          : 0        : , "sv"           :
+showtriggers                             : 0        : , "sv", "cheat"  : Shows trigger brushes
+showtriggers_toggle                      : cmd      :                  : Toggle show triggers
+singlestep                               : 0        : , "cheat"        : Run engine in single step mode ( set next to 1 to advance a frame )
+sk_ally_regen_time                       : 0        : , "sv"           : Time taken for an ally to regenerate a point of health.
+sk_autoaim_mode                          : 1        : , "a", "sv", "rep" :
+sk_npc_arm                               : 1        : , "sv"           :
+sk_npc_chest                             : 1        : , "sv"           :
+sk_npc_head                              : 2        : , "sv"           :
+sk_npc_leg                               : 1        : , "sv"           :
+sk_npc_stomach                           : 1        : , "sv"           :
+sk_player_arm                            : 1        : , "sv"           :
+sk_player_chest                          : 1        : , "sv"           :
+sk_player_head                           : 2        : , "sv"           :
+sk_player_leg                            : 1        : , "sv"           :
+sk_player_stomach                        : 1        : , "sv"           :
+skill                                    : 1        : , "a"            : Game skill level (1-3).
+skip_next_map                            : cmd      :                  : Skips the next map in the map rotation for the server.
+sleep_when_meeting_framerate             : 1        :                  : Sleep instead of spinning if we're meeting the desired framerate.
+smoothstairs                             : 1        : , "sv", "rep"    : Smooth player eye z coordinate when traversing stairs.
+snd_foliage_db_loss                      : 4        : , "cheat"        : foliage dB loss per 1200 units
+snd_gain                                 : 1        : , "cheat"        :
+snd_gain_max                             : 1        : , "cheat"        :
+snd_gain_min                             : 0        : , "cheat"        :
+snd_music_boost                          : 0        : , "sv", "rep"    : Specifies an amount to boost music volume by
+snd_refdb                                : 60       : , "cheat"        : Reference dB at snd_refdist
+snd_refdist                              : 36       : , "cheat"        : Reference distance for snd_refdb
+snd_restart                              : cmd      :                  : Restart sound system.
+snd_sos_show_server_xmit                 : 0        : , "sv", "cheat"  :
+snd_vox_captiontrace                     : 0        :                  : Shows sentence name for sentences which are set not to show captions.
+snd_vox_globaltimeout                    : 300      :                  :
+snd_vox_sectimetout                      : 300      :                  :
+snd_vox_seqtimetout                      : 300      :                  :
+soundpatch_captionlength                 : 2        : , "sv", "rep"    : How long looping soundpatch captions should display for.
+soundscape_debug                         : 0        : , "sv", "cheat"  : When on, draws lines to all env_soundscape entities. Green lines show the active soundscape, red lines show soundscapes that ar
+soundscape_flush                         : cmd      :                  : Flushes the server & client side soundscapes
+spec_freeze_time                         : 4        : , "sv", "cheat", "rep" : Time spend frozen in observer freeze cam.
+spec_freeze_traveltime                   : 0        : , "sv", "cheat", "rep" : Time taken to zoom in to frame a target in observer freeze cam.
+spec_replay_bot                          : 0        : , "sv"           : Enable Spectator Hltv Replay when killed by bot
+spec_replay_cam_delay                    : 5        : , "sv"           : Hltv Replay delay in seconds
+spec_replay_cam_options                  : 0        : , "sv"           : Debug options for replay cam
+spec_replay_leadup_time                  : 5        : , "rep"          : Replay time in seconds before the highlighted event
+spec_replay_message_time                 : 9        : , "rep"          : How long to show the message about Killer Replay after death. The best setting is a bit shorter than spec_replay_autostart_dela
+spec_replay_on_death                     : 0        : , "rep"          : When > 0, sets the mode whereas players see delayed replay, and are segregated into a domain of chat and voice separate from th
+spec_replay_rate_base                    : 1        : , "rep"          : Base time scale of Killer Replay.Experimental.
+spec_replay_rate_limit                   : 3        : , "rep"          : Minimum allowable pause between replay requests in seconds
+spec_replay_round_delay                  : 0        : , "sv"           : Round can be delayed by this much due to someone watching a replay; must be at least 3-4 seconds, otherwise the last replay wil
+spec_replay_winddown_time                : 2        : , "sv"           : The trailing time, in seconds, of replay past the event, including fade-out
+spewdriverinfo                           : cmd      :                  : Spew Driver Info
+spike                                    : cmd      :                  : generates a fake spike
+spincycle                                : cmd      :                  : Cause the engine to spincycle (Debug!!)
+ss_map                                   : cmd      :                  : Start playing on specified map with max allowed splitscreen players.
+ss_voice_hearpartner                     : 0        :                  : Route voice between splitscreen players on same system.
+star_memory                              : cmd      :                  : Dump memory stats
+stats                                    : cmd      :                  : Prints server performance variables
+status                                   : cmd      :                  : Display map and connection status.
+step_spline                              : 0        : , "sv"           :
+stringtable_alwaysrebuilddictionaries    : 0        :                  : Rebuild dictionary file on every level load
+stringtable_showsizes                    : 0        :                  : Show sizes of string tables when building for signon
+stringtable_usedictionaries              : 1        :                  : Use dictionaries for string table networking
+stringtabledictionary                    : cmd      :                  : Create dictionary for current strings.
+studio_queue_mode                        : 1        :                  :
+stuffcmds                                : cmd      :                  : Parses and stuffs command line + commands to command buffer.
+surfaceprop                              : cmd      :                  : Reports the surface properties at the cursor
+sv_accelerate                            : 8        : , "sv", "nf", "rep" : Linear acceleration amount (old value is 5.6)
+sv_accelerate_debug_speed                : 0        : , "sv", "nf", "rep" :
+sv_air_max_horizontal_parachute_ratio    : 0        : , "sv", "rep"    :
+sv_air_max_horizontal_parachute_speed    : 240      : , "sv", "rep"    :
+sv_air_max_wishspeed                     : 30       : , "sv", "rep"    :
+sv_airaccelerate                         : 12       : , "sv", "nf", "rep" :
+sv_airaccelerate_parachute               : 2        : , "sv", "rep"    :
+sv_allchat                               : 1        : , "sv", "nf"     : Players can receive all other players' text chat, team restrictions apply
+sv_allow_coughing                        : 1        : , "sv", "rep"    : Determines whether a player will cough inside smoke if he does not wear a gas mask.
+sv_allow_legacy_cmd_execution_from_client : 0        :                  : Enables old concommand execution behavior allowing remote clients to run any command not explicitly flagged as disallowed.
+sv_allow_lobby_connect_only              : 0        :                  : If set, players may only join this server from matchmaking lobby, may not connect directly.
+sv_allow_thirdperson                     : 0        : , "sv", "rep"    : Allows the server set players in third person mode without the client slamming it back (if cheats are on, all clients can set t
+sv_allow_user_workshop_content           : 0        :                  : Allow users to join with their own workshop content mounted.
+sv_allow_votes                           : 1        : , "sv"           : Allow voting?
+sv_allow_wait_command                    : 1        : , "rep"          : Allow or disallow the wait command on clients connected to this server.
+sv_allowdownload                         : 1        :                  : Allow clients to download files
+sv_allowupload                           : 0        :                  : Allow clients to upload customizations files
+sv_alltalk                               : 1        : , "sv", "nf", "rep" : Deprecated. Replaced with sv_talk_enemy_dead and sv_talk_enemy_living.
+sv_alternateticks                        : 0        :                  : If set, server only simulates entities on even numbered ticks.
+sv_auto_adjust_bot_difficulty            : 1        : , "sv"           : Adjust the difficulty of bots each round based on contribution score.
+sv_auto_full_alltalk_during_warmup_half_end : 1        : , "sv"           : When enabled will automatically turn on full all talk mode in warmup, at halftime and at the end of the match
+sv_autobunnyhopping                      : 0        : , "sv", "rep"    : Players automatically re-jump while holding jump button
+sv_autosave                              : 1        : , "sv"           : Set to 1 to autosave game on level transition. Does not affect autosave triggers.
+sv_benchmark_autovprofrecord             : 0        : , "sv"           : If running a benchmark and this is set, it will record a vprof file over the duration of the benchmark with filename benchmark.
+sv_benchmark_force_start                 : cmd      :                  : Force start the benchmark. This is only for debugging. It's better to set sv_benchmark to 1 and restart the level.
+sv_benchmark_numticks                    : 3300     : , "sv"           : If > 0, then it only runs the benchmark for this # of ticks.
+sv_bonus_challenge                       : 0        : , "sv", "rep"    : Set to values other than 0 to select a bonus map challenge type.
+sv_bots_get_easier_each_win              : 0        : , "sv"           : If > 0, some # of bots will lower thier difficulty each time they win. The argument defines how many will lower their difficult
+sv_bots_get_harder_after_each_wave       : 0        : , "sv"           : If > 0, some # of bots will raise thier difficulty each time CTs beat a Guardian wave. The argument defines how many will raise
+sv_bounce                                : 0        : , "sv", "nf", "rep" : Bounce multiplier for when physically simulated objects collide with other objects.
+sv_bullet_penetration                    : 1        : , "sv", "rep"    : Enable bullet penetration.
+sv_cacheencodedents                      : 1        :                  : If set to 1, does an optimization to prevent extra SendTable_Encode calls.
+sv_chat_proximity                        : -1       : , "sv", "rep"    :
+sv_cheats                                : 0        : , "nf", "rep"    : Allow cheats on server
+sv_clamp_unsafe_velocities               : 1        : , "sv", "rep"    : Whether the server will attempt to clamp velocities that could cause physics bugs or crashes.
+sv_clearhinthistory                      : cmd      :                  : Clear memory of server side hints displayed to the player.
+sv_client_cmdrate_difference             : 0        : , "rep"          : cl_cmdrate is moved to within sv_client_cmdrate_difference units of cl_updaterate before it is clamped between sv_mincmdrate an
+sv_client_max_interp_ratio               : 5        : , "rep"          : This can be used to limit the value of cl_interp_ratio for connected clients (only while they are connected). If sv_client_min_
+sv_client_min_interp_ratio               : 1        : , "rep"          : This can be used to limit the value of cl_interp_ratio for connected clients (only while they are connected).               -1
+sv_client_predict                        : -1       : , "rep"          : This can be used to force the value of cl_predict for connected clients (only while they are connected).    -1 = let clients se
+sv_clip_penetration_traces_to_players    : 1        : , "sv", "rep"    :
+sv_clockcorrection_msecs                 : 30       : , "sv"           : The server tries to keep each player's m_nTickBase withing this many msecs of the server absolute tickcount
+sv_closecaption                          : 2        : , "sv", "rep"    : Enable server-side close captioning: 0 = disabled; 1 = enabled as text chat; 2 = enabled for all sounds
+sv_coach_comm_unrestricted               : 0        : , "sv", "rep"    : When set, ignores coach communication restrictions.
+sv_coaching_enabled                      : 0        : , "sv", "rep"    : Allows spectating and communicating with a team ( 'coach t' or 'coach ct' )
+sv_competitive_minspec                   : 1        : , "sv", "nf", "rep" : Enable to force certain client convars to minimum/maximum values to help prevent competitive advantages.
+sv_competitive_official_5v5              : 0        : , "sv", "nf", "rep" : Enable to force the server to show 5v5 scoreboards and allows spectators to see characters through walls.
+sv_consistency                           : 0        : , "rep"          : Whether the server enforces file consistency for critical files
+sv_contact                               : 0        : , "nf"           : Contact email for server sysop
+sv_crosshair                             : 1        : , "sv", "rep"    : Enable or disable crosshair for server option.
+sv_crouch_spam_penalty                   : 1        : , "sv", "rep"    :
+sv_damage_level                          : 1        : , "sv", "rep"    : Global damage multiplier. 0 - weak (0.5) 1 - normal (1.0) 2 - strong (2.0)
+sv_damage_print_enable                   : 0        : , "sv", "rep"    : Turn this off to disable the player's damage feed in the console after getting killed.
+sv_dc_friends_reqd                       : 0        : , "sv"           : Set this to 0 to allow direct connects to a game in progress even if no presents are present
+sv_deadtalk                              : 1        : , "sv", "nf", "rep" : Dead players can speak (voice, text) to the living
+sv_debug_player_use                      : 0        : , "sv", "rep"    : Visualizes +use logic. Green cross=trace success, Red cross=trace too far, Green box=radius success
+sv_debugmanualmode                       : 0        :                  : Make sure entities correctly report whether or not their network data has changed.
+sv_debugtempentities                     : 0        :                  : Show temp entity bandwidth usage.
+sv_delta_entity_full_buffer_size         : 196608   :                  : Buffer size for delta entities
+sv_deltaprint                            : 0        :                  : Print accumulated CalcDelta profiling data (only if sv_deltatime is on)
+sv_deltatime                             : 0        :                  : Enable profiling of CalcDelta calls
+sv_disable_immunity_alpha                : 0        : , "sv", "rep"    : If set, clients won't slam the player model render settings each frame for immunity [mod authors use this]
+sv_disable_observer_interpolation        : 1        : , "sv", "rep"    : Disallow interpolating between observer targets on this server.
+sv_disable_pas                           : 1        : , "sv", "cheat", "rep" :
+sv_disable_radar                         : 0        : , "sv", "rep"    :
+sv_disablefreezecam                      : 1        : , "sv", "rep"    : Turn on/off freezecam on server
+sv_downloadurl                           : 0        : , "rep"          : Location from which clients can download missing files
+sv_drowning_damage_initial               : 2        : , "sv", "rep"    :
+sv_drowning_damage_max                   : 5        : , "sv", "rep"    :
+sv_dump_class_info                       : cmd      :                  : Dump server class infos.
+sv_dump_class_table                      : cmd      :                  : Dump server class table matching the pattern (substr).
+sv_dump_edicts                           : cmd      :                  : Display a list of edicts allocated on the server.
+sv_dump_serialized_entities_mem          : cmd      :                  : Dump serialized entity allocations stats.
+sv_dumpstringtables                      : 0        : , "cheat"        :
+sv_duplicate_playernames_ok              : 0        : , "rep"          : When enabled player names won't have the (#) in front of their names its the same as another player.
+sv_enable_delta_packing                  : 0        :                  : When enabled, this allows for entity packing to use the property changes for building up the data. This is many times faster, b
+sv_enablebunnyhopping                    : 0        : , "sv", "rep"    : Allow player speed to exceed maximum running speed
+sv_enableoldqueries                      : 0        :                  : Enable support for old style (HL1) server queries
+sv_env_entity_makers_enabled             : 1        : , "sv", "rep"    :
+sv_extra_client_connect_time             : 15       :                  : Seconds after client connect during which extra frames are buffered to prevent non-delta'd update
+sv_extract_ammo_from_dropped_weapons     : 0        : , "sv", "rep"    :
+sv_falldamage_scale                      : 1        : , "sv", "rep"    :
+sv_falldamage_to_below_player_multiplier : 1        : , "sv", "rep"    : Scale damage when distributed across two players
+sv_falldamage_to_below_player_ratio      : 150      : , "sv", "rep"    : Landing on a another player's head gives them this ratio of the damage.
+sv_filterban                             : 1        :                  : Set packet filtering by IP mode
+sv_footstep_sound_frequency              : 0        : , "sv", "cheat", "rep" : How frequent to hear the player's step sound or how fast they appear to be running from first person.
+sv_force_transmit_ents                   : 0        : , "sv"           : Will transmit all entities to client, regardless of PVS conditions (will still skip based on transmit flags, however).
+sv_force_transmit_players                : 0        : , "sv"           : Will transmit players to all clients regardless of PVS checks.
+sv_forcepreload                          : 0        : , "a"            : Force server side preloading.
+sv_friction                              : 5        : , "sv", "nf", "rep" : World friction.
+sv_full_alltalk                          : 0        : , "sv", "rep"    : Any player (including Spectator team) can speak to any other player
+sv_game_mode_convars                     : cmd      :                  : Display the values of the convars for the current game_mode.
+sv_game_mode_list                        : cmd      :                  : Display available gamemodes for 'game_mode'
+sv_gameinstructor_disable                : 0        : , "sv", "rep"    : Force all clients to disable their game instructors.
+sv_getinfo                               : cmd      :                  : Show user info of a connected client
+sv_grassburn                             : 1        : , "sv", "rep"    :
+sv_gravity                               : 800      : , "sv", "nf", "rep" : World gravity.
+sv_grenade_trajectory                    : 0        : , "sv", "cheat", "rep" : Shows grenade trajectory visualization in-game.
+sv_grenade_trajectory_dash               : 0        : , "sv", "rep"    : Dot-dash style grenade trajectory arc
+sv_grenade_trajectory_thickness          : 0        : , "sv", "rep"    : Visible thickness of grenade trajectory arc
+sv_grenade_trajectory_time               : 20       : , "sv", "rep"    : Length of time grenade trajectory remains visible.
+sv_grenade_trajectory_time_spectator     : 4        : , "sv", "rep"    : Length of time grenade trajectory remains visible as a spectator.
+sv_health_approach_enabled               : 0        : , "sv", "rep"    :
+sv_health_approach_speed                 : 10       : , "sv", "rep"    :
+sv_hibernate_ms                          : 20       :                  : # of milliseconds to sleep per frame while hibernating
+sv_hibernate_ms_vgui                     : 20       :                  : # of milliseconds to sleep per frame while hibernating but running the vgui dedicated server frontend
+sv_hibernate_postgame_delay              : 5        :                  : # of seconds to wait after final client leaves before hibernating.
+sv_hibernate_punt_tv_clients             : 0        :                  : When enabled will punt all GOTV clients during hibernation
+sv_hibernate_when_empty                  : 1        :                  : Puts the server into extremely low CPU usage mode when no clients connected
+sv_hibernate_zombie_bot_count            : 12       : , "sv"           : Spawn N bots when sv_hibernate_zombie_mode is active.
+sv_hibernate_zombie_mode                 : 1        :                  : Don't confuse with game mode. If enabled, this will spawn bots so they will play on server when no players are connected, essen
+sv_highlight_distance                    : 4096     : , "sv", "rep"    :
+sv_hp_leech                              : 0        : , "sv", "rep"    : Reward attacker with health after killing someone.
+sv_infinite_ammo                         : 0        : , "sv", "rep"    : Player's active weapon will never run out of ammo. If set to 2 then player has infinite total ammo but still has to reload the
+sv_jump_impulse                          : 301      : , "sv", "rep"    : Initial upward velocity for player jumps; sqrt(2*gravity*height).
+sv_kick_ban_duration                     : 3        : , "sv", "nf", "rep" : How long should a kick ban from the server should last (in minutes)
+sv_kick_bots_on_full_servers             : 1        :                  : Whether bot should be removed from the game in order to give a free slot for a human player on full servers or not.
+sv_ladder_scale_speed                    : 1        : , "sv", "rep"    : Affects the ladder speed for going up and down.
+sv_lagcompensateself                     : 0        : , "sv", "cheat"  : Player can lag compensate themselves.
+sv_lagcompensationforcerestore           : 1        : , "sv", "cheat"  : Don't test validity of a lag comp restore, just do it.
+sv_lan                                   : 0        :                  : Server is a lan server ( no heartbeat, no authentication, no non-class C addresses )
+sv_lean_enabled                          : 1        : , "sv", "rep"    : Enables or disables leaning feature.
+sv_ledge_mantle_helper                   : 1        : , "sv", "rep"    : 1=Only improves success of jump+ducks to windows or vents (jump+duck to duck), 2=Improves success of all jump+ducks to ledges,
+sv_load_forced_client_names_file         : cmd      :                  : Loads a file containing SteamID64 names for clients
+sv_log_http_record_before_any_listeners  : 0        : , "sv"           :
+sv_log_onefile                           : 0        : , "a"            : Log server information to only one file.
+sv_logbans                               : 0        : , "a"            : Log server bans in the server logs.
+sv_logblocks                             : 0        :                  : If true when log when a query is blocked (can cause very large log files)
+sv_logdownloadlist                       : 0        :                  :
+sv_logecho                               : 1        : , "a"            : Echo log information to the console.
+sv_logfile                               : 1        : , "a"            : Log server information in the log file.
+sv_logflush                              : 0        : , "a"            : Flush the log file to disk on each write (slow).
+sv_logsdir                               : 0        : , "a"            : Folder in the game directory where server logs will be stored.
+sv_logsecret                             : 0        :                  : If set then include this secret when doing UDP logging (will use 0x53 as packet type, not usual 0x52)
+sv_logsocket                             : 1        :                  : Uses a specific outgoing socket for sv udp logging
+sv_logsocket2                            : 1        :                  : Uses a specific outgoing socket for second source of sv udp logging
+sv_logsocket2_substr                     : 0        :                  : Uses a substring match for second source of sv udp logging
+sv_massreport                            : 0        : , "sv"           :
+sv_master_share_game_socket              : 1        :                  : Use the game's socket to communicate to the master server. If this is 0, then it will create a socket on -steamport + 1 to comm
+sv_max_allowed_net_graph                 : 4        : , "sv", "nf", "rep" : Determines max allowed net_graph value for clients.
+sv_max_distance_transmit_footsteps       : 1250     : , "sv", "rep"    : Maximum distance to transmit footstep sound effects.
+sv_max_dropped_packets_to_process        : 10       :                  : Max dropped packets to process. Lower settings prevent lagged players from simulating too far in the past. Setting of 0 disable
+sv_max_queries_sec                       : 10       :                  : Maximum queries per second to respond to from a single IP address.
+sv_max_queries_sec_global                : 500      :                  : Maximum queries per second to respond to from anywhere.
+sv_max_queries_tracked_ips_max           : 50000    :                  : Window over which to average queries per second averages.
+sv_max_queries_tracked_ips_prune         : 10       :                  : Window over which to average queries per second averages.
+sv_max_queries_window                    : 30       :                  : Window over which to average queries per second averages.
+sv_max_usercmd_future_ticks              : 8        : , "sv"           : Prevents clients from running usercmds too far in the future. Prevents speed hacks.
+sv_max_usercmd_move_magnitude            : 1000     : , "sv"           : Maximum move magnitude that can be requested by client.
+sv_maxclientframes                       : 128      :                  :
+sv_maxcmdrate                            : 64       : , "rep"          : (If sv_mincmdrate is > 0), this sets the maximum value for cl_cmdrate.
+sv_maxrate                               : 0        : , "rep"          : Max bandwidth rate allowed on server, 0 == unlimited
+sv_maxreplay                             : 0        :                  : Maximum replay time in seconds
+sv_maxroutable                           : 1200     :                  : Server upper bound on net_maxroutable that a client can use.
+sv_maxspeed                              : 320      : , "sv", "nf", "rep" :
+sv_maxunlag                              : 0        : , "sv"           : Maximum lag compensation in seconds
+sv_maxupdaterate                         : 64       : , "rep"          : Maximum updates per second that the server will allow
+sv_maxuptimelimit                        : 0        :                  : If set, whenever a game ends, if the server uptime exceeds this number of hours, the server will exit.
+sv_maxusrcmdprocessticks                 : 16       : , "sv"           : Maximum number of client-issued usrcmd ticks that can be replayed in packet loss conditions, 0 to allow no restrictions
+sv_maxusrcmdprocessticks_holdaim         : 1        : , "sv"           : Hold client aim for multiple server sim ticks when client-issued usrcmd contains multiple actions (0: off; 1: hold this server
+sv_maxusrcmdprocessticks_warning         : -1       : , "sv"           : Print a warning when user commands get dropped due to insufficient usrcmd ticks allocated, number of seconds to throttle, negat
+sv_maxvelocity                           : 6500     : , "sv", "rep"    : Maximum speed any ballistically moving object is allowed to attain per axis.
+sv_memlimit                              : 0        :                  : If set, whenever a game ends, if the total memory used by the server is greater than this # of megabytes, the server will exit.
+sv_min_jump_landing_sound                : 260      : , "sv", "rep"    :
+sv_mincmdrate                            : 64       : , "rep"          : This sets the minimum value for cl_cmdrate. 0 == unlimited.
+sv_minrate                               : 16000    : , "rep"          : Min bandwidth rate allowed on server, 0 == unlimited
+sv_minupdaterate                         : 64       : , "rep"          : Minimum updates per second that the server will allow
+sv_minuptimelimit                        : 0        :                  : If set, whenever a game ends, if the server uptime is less than this number of hours, the server will continue running regardle
+sv_multiplayer_maxtempentities           : 32       :                  :
+sv_multiplayer_sounds                    : 20       :                  :
+sv_mute_automatic_radio_voice            : 0        : , "sv", "rep"    : To mute automatic radio voices (reloading, enemy down, etc.. )
+sv_new_delta_bits                        : 1        :                  :
+sv_noclipaccelerate                      : 5        : , "a", "sv", "nf", "rep" :
+sv_noclipduringpause                     : 0        : , "sv", "cheat", "rep" : If cheats are enabled, then you can noclip with the game paused (for doing screenshots, etc.).
+sv_noclipspeed                           : 5        : , "a", "sv", "nf", "rep" :
+sv_nowinpanel                            : 0        : , "sv"           : Turn on/off win panel on server
+sv_npc_talker_maxdist                    : 1024     : , "sv"           : NPCs over this distance from the player won't attempt to speak.
+sv_occlude_players                       : 1        : , "sv"           :
+sv_outofammo_indicator                   : 0        : , "sv", "rep"    :
+sv_parallel_packentities                 : 1        :                  :
+sv_parallel_send                         : 0        :                  : Pack and send snapshots in parallel for smoother server tick rate at the expense of spending more CPU.
+sv_parallel_sendsnapshot                 : 0        :                  :
+sv_password                              : 0        : , "nf", "prot", "norecord" : Server password for entry into multiplayer games
+sv_pausable                              : 0        :                  : Is the server pausable.
+sv_phys_props_block_movers               : 0        : , "sv"           :
+sv_player_gibbing                        : 1        : , "sv", "rep"    : 0 = disable player gibbing. 1 = enable standard player gibbing. 2 = always gib regardless of damage type
+sv_player_health                         : 100      : , "sv", "nf", "rep" : Maximum player health.
+sv_player_parachute_velocity             : -200     : , "sv", "rep"    :
+sv_player_stack_max                      : 0        : , "sv", "rep"    : Players are slided off each other after exceeding this stack level.
+sv_playerperfhistorycount                : 20       : , "sv"           : Number of samples to maintain in player perf history
+sv_precacheinfo                          : cmd      :                  : Show precache info.
+sv_prone_enabled                         : 1        : , "sv", "rep"    : Enables or disables prone.
+sv_prop_door_open_speed_scale            : 1        : , "sv", "rep"    :
+sv_pure                                  : cmd      :                  : Show user data.
+sv_pure_allow_loose_file_loads           : 1        :                  : If set to 1, clients may load non-vpk files from pure protected directories.
+sv_pure_allow_missing_files              : 1        :                  : If set to 1, the server will allow clients to play if files they loaded are missing on server, otherwise treat client as file m
+sv_pure_consensus                        : 100000000.000 :                  : Minimum number of file hashes to agree to form a consensus.
+sv_pure_kick_clients                     : 1        :                  : If set to 1, the server will kick clients with mismatching files. Otherwise, it will issue a warning to the client.
+sv_pure_retiretime                       : 900      :                  : Seconds of server idle time to flush the sv_pure file hash cache.
+sv_pure_trace                            : 0        :                  : If set to 1, the server will print a message whenever a client is verifying a CRC for a file.
+sv_pvsskipanimation                      : 1        : , "a", "sv"      : Skips SetupBones when npc's are outside the PVS
+sv_querycache_stats                      : cmd      :                  : Display status of the query cache (client only)
+sv_quota_stringcmdspersecond             : 40       :                  : How many string commands per second clients are allowed to submit, 0 to disallow all string commands
+sv_rcon_banpenalty                       : 0        :                  : Number of minutes to ban users who fail rcon authentication
+sv_rcon_log                              : 1        :                  : Enable/disable rcon logging.
+sv_rcon_maxfailures                      : 10       :                  : Max number of times a user can fail rcon authentication before being banned
+sv_rcon_minfailures                      : 5        :                  : Number of times a user can fail rcon authentication in sv_rcon_minfailuretime before being banned
+sv_rcon_minfailuretime                   : 30       :                  : Number of seconds to track failed rcon authentications
+sv_rcon_whitelist_address                : 0        :                  : When set, rcon failed authentications will never ban this address, e.g. '127.0.0.1'
+sv_regeneration_force_on                 : 0        : , "sv", "cheat"  : Cheat to test regenerative health systems
+sv_regeneration_wait_time                : 1        : , "sv", "rep"    :
+sv_region                                : -1       :                  : The region of the world to report this server in.
+sv_reliableavatardata                    : 0        : , "rep"          : When enabled player avatars are exchanged via gameserver (0: off, 1: players, 2: server)
+sv_replaybots                            : 0        :                  : If set to 1, the server records data needed to replay network stream from bot's perspective
+sv_reservation_grace                     : 5        :                  : Time in seconds given for a lobby reservation.
+sv_reservation_tickrate_adjustment       : 0        :                  : Adjust server tickrate upon reservation
+sv_reservation_timeout                   : 45       :                  : Time in seconds before lobby reservation expires.
+sv_runcmds                               : 1        : , "sv"           :
+sv_script_think_interval                 : 0        : , "sv"           :
+sv_search_key                            : 0        :                  : When searching for a dedicated server from lobby, restrict search to only dedicated servers having the same sv_search_key.
+sv_send_stats                            : cmd      :                  : show stats of running parallel send
+sv_server_verify_blood_on_player         : 1        : , "sv", "cheat", "rep" :
+sv_setsteamaccount                       : cmd      :                  : token Set game server account token to use for logging in to a persistent game server account
+sv_show_bot_difficulty_in_name           : 0        : , "sv", "rep"    : 0 = hide bot difficulty in bot name, 1 = show bot difficulty in bot name
+sv_show_cull_props                       : 0        :                  : Print out props that are being culled/added by recipent proxies.
+sv_show_state_transitions                : -2       : , "sv", "cheat"  : Value: <ent index or -1 for all>. Show player state transitions.
+sv_show_team_equipment_force_on          : 1        : , "sv", "rep"    : Force on if not prohibited
+sv_show_team_equipment_prohibit          : 0        : , "sv", "nf", "rep" : Determines whether +cl_show_team_equipment is prohibited.
+sv_show_usermessage                      : 0        :                  : Shows the user messages that the server is sending to clients. Setting this to 2 will show the contents of the message
+sv_show_voip_indicator_for_enemies       : 0        : , "sv", "rep"    : Makes it so the voip icon is shown over enemies as well as allies when they are talking
+sv_showbullethits                        : 0        : , "sv", "rep"    : 1=show hits and near misses, 2=show hits only
+sv_showimpacts                           : 0        : , "sv", "rep"    : Shows client (red) and server (blue) bullet impact point (1=both, 2=client-only, 3=server-only)
+sv_showimpacts_penetration               : 0        : , "sv", "rep"    : Shows extra data when bullets penetrate. (use sv_showimpacts_time to increase time shown)
+sv_showimpacts_time                      : 4        : , "sv", "rep"    : Duration bullet impact indicators remain before disappearing
+sv_showladders                           : 0        : , "sv"           : Show bbox and dismount points for all ladders (must be set before level load.)
+sv_showlagcompensation                   : 0        : , "sv", "cheat"  : Show lag compensated hitboxes whenever a player is lag compensated.
+sv_showlagcompensation_duration          : 4        : , "sv", "cheat"  : Duration to show lag-compensated hitboxes
+sv_showplayerhitboxes                    : 0        : , "sv", "rep"    : Show lag compensated hitboxes for the specified player index whenever a player fires.
+sv_showtags                              : cmd      :                  : Describe current gametags.
+sv_shutdown                              : cmd      :                  : Sets the server to shutdown when all games have completed
+sv_signon_dos_disconnect                 : 20       :                  : Number of extra signon state confirmations required to disconnect a misbehaving client.
+sv_skirmish_id                           : 0        : , "sv", "rep"    : Dedicated server skirmish id to run
+sv_skyname                               : 0        : , "a", "sv", "rep" : Current name of the skybox texture
+sv_sound_discardextraunreliable          : 1        :                  :
+sv_soundemitter_reload                   : cmd      :                  : Flushes the sounds.txt system
+sv_soundemitter_trace                    : -1       : , "sv", "rep"    : Show all EmitSound calls including their symbolic name and the actual wave file they resolved to. (-1 = for nobody, 0 = for eve
+sv_soundscape_printdebuginfo             : cmd      :                  : print soundscapes
+sv_spec_hear                             : 1        : , "sv", "nf", "rep" : Determines who spectators can hear: 0: only spectators; 1: all players; 2: spectated team; 3: self only; 4: nobody
+sv_spec_post_death_additional_time       : 0        : , "sv", "rep"    :
+sv_specaccelerate                        : 5        : , "a", "sv", "nf", "rep" :
+sv_specnoclip                            : 0        : , "a", "sv", "nf", "rep" :
+sv_specspeed                             : 3        : , "a", "sv", "nf", "rep" :
+sv_sprint_enabled                        : 1        : , "sv", "rep"    : Controls sprinting
+sv_staminabreath                         : 0        : , "sv", "rep"    : Stamina penalty for breathing scope weapons
+sv_staminadrainrate                      : 10       : , "sv", "rep"    : Rate at which stamina drains (units/sec)
+sv_staminajumpcost                       : 10       : , "sv", "rep"    : Stamina penalty for jumping
+sv_staminalandcost                       : 0        : , "sv", "rep"    : Stamina penalty for landing
+sv_staminamax                            : 100      : , "sv", "rep"    : Maximum stamina
+sv_staminarecoveryrate                   : 10       : , "sv", "rep"    : Rate at which stamina recovers (units/sec)
+sv_standable_normal                      : 0        : , "sv", "rep"    :
+sv_stats                                 : 1        :                  : Collect CPU usage stats
+sv_steamauth_enforce                     : 2        :                  : By default, player must maintain a reliable connection to Steam servers. When player Steam session drops, enforce it: 2 = insta
+sv_steamgroup                            : 0        : , "nf"           : The ID of the steam group that this server belongs to. You can find your group's ID on the admin profile page in the steam comm
+sv_steamgroup_exclusive                  : 0        :                  : If set, only members of Steam group will be able to join the server when it's empty, public people will be able to join the ser
+sv_stopspeed                             : 80       : , "sv", "nf", "rep" : Minimum stopping speed when on ground.
+sv_stressbots                            : 0        :                  : If set to 1, the server calculates data and fills packets to bots. Used for perf testing.
+sv_strict_notarget                       : 0        : , "sv"           : If set, notarget will cause entities to never think they are in the pvs
+sv_tags                                  : 0        : , "nf"           : Server tags. Used to provide extra information to clients when they're browsing for servers. Separate tags with a comma.
+sv_talk_after_dying_time                 : 0        : , "sv", "rep"    : The number of seconds a player can continue talking after dying as if they were still alive
+sv_talk_enemy_dead                       : 1        : , "sv", "rep"    : Dead players can hear all dead enemy communication (voice, chat)
+sv_talk_enemy_living                     : 1        : , "sv", "rep"    : Living players can hear all living enemy communication (voice, chat)
+sv_teamid_overhead                       : 1        : , "sv", "nf", "rep" : Shows teamID over player's heads.  0 = off, 1 = on
+sv_teamid_overhead_always_prohibit       : 0        : , "sv", "nf", "rep" : Determines whether cl_teamid_overhead_always is prohibited.
+sv_teamid_overhead_maxdist               : 0        : , "sv", "rep"    : If >0, server will override cl_teamid_overhead_maxdist
+sv_teamid_overhead_maxdist_spec          : 0        : , "sv", "rep"    : If >0, server will override cl_teamid_overhead_maxdist_spec
+sv_temp_baseline_string_table_buffer_size : 1048576  :                  : Buffer size for writing string table baselines
+sv_test_scripted_sequences               : 0        : , "sv"           : Tests for scripted sequences that are embedded in the world. Run through your map with this set to check for NPCs falling throu
+sv_teststepsimulation                    : 1        : , "sv"           :
+sv_thinktimecheck                        : 0        : , "sv"           : Check for thinktimes all on same timestamp.
+sv_threaded_init                         : 0        : , "sv"           :
+sv_timebetweenducks                      : 0        : , "sv", "rep"    : Minimum time before recognizing consecutive duck key
+sv_timeout                               : 65       :                  : After this many seconds without a message from a client, the client is dropped
+sv_turbophysics                          : 0        : , "sv", "rep"    : Turns on turbo physics
+sv_turning_inaccuracy_angle_min          : 4        : , "sv", "cheat", "rep" :
+sv_turning_inaccuracy_decay              : 0        : , "sv", "cheat", "rep" :
+sv_turning_inaccuracy_enabled            : 0        : , "sv", "cheat", "rep" :
+sv_unlockedchapters                      : 1        : , "a", "sv"      :
+sv_usercmd_custom_random_seed            : 0        : , "sv"           : When enabled server will populate an additional random seed independent of the client
+sv_validate_edict_change_infos           : 0        :                  : Verify that edict changeinfos are being calculated properly (used to debug local network backdoor mode).
+sv_vehicle_autoaim_scale                 : 8        : , "sv"           :
+sv_velocitymod_dmgtype_burn              : 0        : , "sv", "rep"    : Sets the players speed modifier when hit by Damagetype DMG_BURN
+sv_visiblemaxplayers                     : -1       :                  : Overrides the max players reported to prospective clients
+sv_voice_proximity                       : -1       : , "sv", "rep"    :
+sv_voice_proximity_enemy                 : 0        : , "sv", "rep"    : If enabled, enemy voice chat will be positional
+sv_voice_proximity_positional            : 0        : , "sv", "rep"    :
+sv_voicecodec                            : 0        : , "rep"          : Specifies which voice codec DLL to use in a game. Set to the name of the DLL without the extension.
+sv_voiceenable                           : 1        : , "a", "nf"      :
+sv_vote_allow_in_warmup                  : 0        : , "sv"           : Allow voting during warmup?
+sv_vote_allow_spectators                 : 1        : , "sv"           : Allow spectators to initiate votes?
+sv_vote_command_delay                    : 2        : , "sv"           : How long after a vote passes until the action happens
+sv_vote_count_spectator_votes            : 0        : , "sv"           : Allow spectators to vote on issues?
+sv_vote_creation_timer                   : 120      : , "sv"           : How often someone can individually call a vote.
+sv_vote_disallow_kick_on_match_point     : 0        : , "sv"           : Disallow vote kicking on the match point round.
+sv_vote_failure_timer                    : 300      : , "sv"           : A vote that fails cannot be re-submitted for this long
+sv_vote_ignore_bots                      : 1        : , "sv", "cheat"  : For debugging, allow bots to be considered voters
+sv_vote_issue_ban_allowed                : 0        : , "sv", "nf", "rep" : Can people hold votes to ban players from the server?
+sv_vote_issue_bots_allowed               : 1        : , "sv", "rep"    :
+sv_vote_issue_change_bot_difficulty      : 1        : , "sv", "rep"    :
+sv_vote_issue_change_bot_ratio           : 1        : , "sv", "rep"    :
+sv_vote_issue_change_gamemode            : 1        : , "sv"           : Can people hold votes to change gamemode?
+sv_vote_issue_change_nextgamemode        : 1        : , "sv"           : Can people hold votes to change next gamemode?
+sv_vote_issue_changelevel_allowed        : 1        : , "sv"           : Can people hold votes to change levels?
+sv_vote_issue_chat_mute_allowed          : 1        : , "sv", "rep"    :
+sv_vote_issue_kick_allowed               : 1        : , "sv", "nf", "rep" : Can people hold votes to kick players from the server?
+sv_vote_issue_kick_quorum_ratio          : 0        : , "sv", "nf", "rep" : The minimum ratio of players needed to vote on a kick issue to resolve it.
+sv_vote_issue_kick_spectators            : 0        : , "sv", "nf", "rep" : Allow players to kick spectators.
+sv_vote_issue_loadbackup_allowed         : 1        : , "sv", "nf", "rep" : Can people hold votes to load match from backup?
+sv_vote_issue_loadbackup_spec_authoritative : 0        : , "sv"           : When enabled, admins load match from backup without players vote
+sv_vote_issue_loadbackup_spec_only       : 0        : , "sv", "nf", "rep" : When enabled, only admins load match from backup
+sv_vote_issue_loadbackup_spec_safe       : 1        : , "sv"           : When enabled, admins load match from backup in safe time of the round only
+sv_vote_issue_matchready_allowed         : 1        : , "sv"           : Can people hold votes to ready/unready the match?
+sv_vote_issue_nextlevel_allowextend      : 1        : , "sv"           : Allow players to extend the current map?
+sv_vote_issue_nextlevel_choicesmode      : 1        : , "sv"           : Present players with a list of lowest playtime maps to choose from?
+sv_vote_issue_pause_match_allowed        : 1        : , "sv"           : Can people hold votes to pause/unpause the match?
+sv_vote_issue_pause_match_spec_only      : 0        : , "sv", "nf", "rep" : When enabled, only admins start technical pause
+sv_vote_issue_restart_game_allowed       : 1        : , "sv"           : Can people hold votes to restart the game?
+sv_vote_issue_restrict_classes           : 1        : , "sv"           : Can people hold votes to restrict classes?
+sv_vote_issue_restrict_items             : 1        : , "sv"           : Can people hold votes to restrict weapons?
+sv_vote_issue_scramble_teams_allowed     : 1        : , "sv"           : Can people hold votes to scramble the teams?
+sv_vote_issue_surrrender_allowed         : 1        : , "sv"           : Can people hold votes to surrender?
+sv_vote_issue_swap_teams_allowed         : 1        : , "sv"           : Can people hold votes to swap the teams?
+sv_vote_issue_timeout_allowed            : 1        : , "sv"           : Can people hold votes to time out?
+sv_vote_issue_voice_chat_mute_allowed    : 1        : , "sv", "rep"    :
+sv_vote_kick_ban_duration                : 30       : , "sv", "nf", "rep" : How long should a kick vote ban someone from the server? (in minutes)
+sv_vote_kick_min_players                 : 4        : , "sv", "nf", "rep" : Minimum players needed to start a kick vote
+sv_vote_quorum_ratio                     : 0        : , "sv"           : The minimum ratio of players needed to vote on an issue to resolve it.
+sv_vote_timer_duration                   : 15       : , "sv"           : How long to allow voting on an issue
+sv_walkable_normal                       : 0        : , "sv", "rep"    :
+sv_warn_friendly_damage_interval         : 3        : , "sv", "cheat"  : Defines how frequently the server notifies clients that a player damaged a friend
+sv_water_movespeed_multiplier            : 0        : , "sv", "rep"    :
+sv_water_swim_mode                       : 0        : , "sv", "rep"    :
+sv_workshop_allow_other_maps             : 1        : , "sv"           : When hosting a workshop collection, users can play other workshop map on this server when it is empty and then mapcycle into th
+sys_minidumpexpandedspew                 : 0        :                  :
+sys_minidumpspewlines                    : 500      :                  : Lines of crash dump console spew to keep.
+template_debug                           : 0        : , "sv"           :
+test_dispatcheffect                      : cmd      :                  : Test a clientside dispatch effect.  Usage: test_dispatcheffect <effect name> <distance away> <flags> <magnitude> <scale>  Defau
+Test_EHandle                             : cmd      :                  :
+test_entity_blocker                      : cmd      :                  : Test command that drops an entity blocker out in front of the player.
+Test_InitRandomEntitySpawner             : cmd      :                  :
+Test_Loop                                : cmd      :                  : Test_Loop <loop name> - loop back to the specified loop start point unconditionally.
+Test_LoopCount                           : cmd      :                  : Test_LoopCount <loop name> <count> - loop back to the specified loop start point the specified # of times.
+Test_LoopForNumSeconds                   : cmd      :                  : Test_LoopForNumSeconds <loop name> <time> - loop back to the specified start point for the specified # of seconds.
+test_outtro_stats                        : cmd      :                  :
+Test_ProxyToggle_EnableProxy             : cmd      :                  :
+Test_ProxyToggle_SetValue                : cmd      :                  :
+Test_RandomChance                        : cmd      :                  : Test_RandomChance <percent chance, 0-100> <token1> <token2...> - Roll the dice and maybe run the command following the percenta
+Test_RandomizeInPVS                      : cmd      :                  :
+Test_RemoveAllRandomEntities             : cmd      :                  :
+Test_RunFrame                            : cmd      :                  :
+Test_SendKey                             : cmd      :                  :
+Test_SpawnRandomEntities                 : cmd      :                  :
+Test_StartLoop                           : cmd      :                  : Test_StartLoop <loop name> - Denote the start of a loop. Really just defines a named point you can jump to.
+Test_StartScript                         : cmd      :                  : Start a test script running..
+Test_Wait                                : cmd      :                  :
+Test_WaitForCheckPoint                   : cmd      :                  :
+testscript_debug                         : 0        :                  : Debug test scripts.
+testscript_running                       : 0        :                  : Set to true when test scripts are running
+tf_arena_max_streak                      : 5        : , "sv", "nf", "rep" : Teams will be scrambled if one team reaches this streak
+tf_arena_preround_time                   : 10       : , "sv", "nf", "rep" : Length of the Pre-Round time
+tf_escort_score_rate                     : 1        : , "sv", "cheat"  : Score for escorting the train, in points per second
+think_limit                              : 0        : , "sv", "rep"    : Maximum think time in milliseconds, warning is printed if this is exceeded.
+thread_test_tslist                       : cmd      :                  :
+thread_test_tsqueue                      : cmd      :                  :
+threadpool_affinity                      : 1        :                  : Enable setting affinity
+threadpool_cycle_reserve                 : cmd      :                  : Cycles threadpool reservation by powers of 2
+threadpool_reserve                       : 0        :                  : Consume the specified number of threads in the thread pool
+threadpool_run_tests                     : cmd      :                  :
+throttle_expensive_ai                    : 1        : , "sv"           :
+timeleft                                 : cmd      :                  : prints the time remaining in the match
+toggle                                   : cmd      :                  : Toggles a convar on or off, or cycles through a set of values.
+trace_report                             : 0        : , "sv"           :
+traceattack                              : cmd      :                  : traceattack damage hitgroup
+tv_advertise_watchable                   : 0        : , "nf", "prot", "norecord" : GOTV advertises the match as watchable via game UI, clients watching via UI will not need to type password
+tv_allow_autorecording_index             : -1       : , "sv"           : When >=0 restricts autorecording only to the specified TV index
+tv_allow_camera_man_override             : 0        :                  : Allows cameraman_override to have effect. When this is set, the primary interactive caster will have all the relevant fields pr
+tv_allow_static_shots                    : 1        : , "sv"           : Auto director uses fixed level cameras for shots
+tv_autorecord                            : 0        :                  : Automatically records all games as GOTV demos.
+tv_autoretry                             : 1        :                  : Relay proxies retry connection after network timeout
+tv_broadcast                             : 0        :                  : Automatically broadcasts all games as GOTV demos through Steam.
+tv_broadcast1                            : 0        :                  : Automatically broadcasts all games as GOTV[1] demos through Steam.
+tv_broadcast_keyframe_interval           : 3        :                  : The frequency, in seconds, of sending keyframes and delta fragments to the broadcast relay server
+tv_broadcast_keyframe_interval1          : 3        :                  : The frequency, in seconds, of sending keyframes and delta fragments to the broadcast1 relay server
+tv_broadcast_max_requests                : 20       :                  : Max number of broadcast http requests in flight. If there is a network issue, the requests may start piling up, degrading serve
+tv_broadcast_max_requests1               : 20       :                  : Max number of broadcast1 http requests in flight. If there is a network issue, the requests may start piling up, degrading serv
+tv_broadcast_resend                      : cmd      :                  : resend broadcast data to broadcast relay
+tv_broadcast_server_info_message_size_kb : 512      :                  : The size, in KB, of the server info message size for tv broadcasts.
+tv_broadcast_startup_resend_interval     : 10       :                  : The interval, in seconds, of re-sending startup data to the broadcast relay server (useful in case relay crashes, restarts or s
+tv_broadcast_status                      : cmd      :                  : Print out broadcast status
+tv_broadcast_url                         : 0        :                  : URL of the broadcast relay
+tv_broadcast_url1                        : 0        :                  : URL of the broadcast relay1
+tv_challenge_steam_iprange               : 0        :                  : Comma-separated IP ranges which require Steam3 challenge protocol even for GOTV connections
+tv_chatgroupsize                         : 0        :                  : Set the default chat group size
+tv_chattimelimit                         : 8        :                  : Limits spectators to chat only every n seconds
+tv_clients                               : cmd      :                  : Shows list of connected GOTV clients [-instance <inst> ]
+tv_debug                                 : 0        :                  : GOTV debug info.
+tv_delay                                 : 10       : , "sv"           : GOTV broadcast delay in seconds
+tv_delay1                                : 15       : , "sv"           : GOTV[instance 1] broadcast delay in seconds
+tv_delaymapchange                        : 1        : , "sv"           : Delays map change until broadcast is complete
+tv_deltacache                            : 2        :                  : Enable delta entity bit stream cache
+tv_dispatchmode                          : 1        :                  : Dispatch clients to relay proxies: 0=never, 1=if appropriate, 2=always
+tv_dispatchweight                        : 1        :                  : Dispatch clients to relay proxies based on load, 1.25 will prefer for every 4 local clients to put 5 clients on every connected
+tv_enable                                : 0        : , "nf"           : Activates GOTV on server (0=off;1=on;2=on when reserved)
+tv_enable1                               : 0        : , "nf"           : Activates GOTV[1] on server (0=off;1=on;2=on when reserved)
+tv_enable_delta_frames                   : 1        :                  : Indicates whether or not the tv should use delta frames for storage of intermediate frames. This takes more CPU but significant
+tv_encryptdata_key                       : 0        :                  : When set to a valid key communication messages will be encrypted for GOTV
+tv_encryptdata_key_pub                   : 0        :                  : When set to a valid key public communication messages will be encrypted for GOTV
+tv_maxclients                            : 128      :                  : Maximum client number on GOTV server.
+tv_maxclients_relayreserved              : 0        :                  : Reserves a certain number of GOTV client slots for relays.
+tv_maxrate                               : 196608   :                  : Max GOTV spectator bandwidth rate allowed, 0 == unlimited
+tv_mem                                   : cmd      :                  : hltv memory statistics
+tv_msg                                   : cmd      :                  : Send a screen message to all clients [-instance <inst> ]
+tv_name                                  : 0        :                  : GOTV host name
+tv_overridemaster                        : 0        :                  : Overrides the GOTV master root address.
+tv_password                              : 0        : , "nf", "prot", "norecord" : GOTV password for all clients
+tv_playcast_delay_prediction             : 1        :                  :
+tv_playcast_retry_timeout                : 12       :                  : In case of intermittent network problems, how long should playcast retry fragment retrieval before resorting to resync
+tv_port                                  : 27020    :                  : Host GOTV[0] port
+tv_port1                                 : 27021    :                  : Host GOTV[1] port
+tv_record                                : cmd      :                  : Starts GOTV demo recording [-instance <inst> ]
+tv_relay                                 : cmd      :                  : Connect to GOTV server and relay broadcast.
+tv_relaypassword                         : 0        : , "nf", "prot", "norecord" : GOTV password for relay proxies
+tv_relayradio                            : 1        : , "sv"           : Relay team radio commands to TV: 0=off, 1=on
+tv_relaytextchat                         : 1        : , "sv"           : Relay text chat data: 0=off, 1=say, 2=say+say_team
+tv_relayvoice                            : 1        :                  : Relay voice data: 0=off, 1=on
+tv_retry                                 : cmd      :                  : Reconnects the GOTV relay proxy
+tv_secure_bypass                         : 0        :                  : Bypass secure challenge on GOTV port
+tv_snapshotrate                          : 32       : , "rep"          : Snapshots broadcasted per second
+tv_snapshotrate1                         : 32       :                  : Snapshots broadcasted per second, GOTV[1]
+tv_status                                : cmd      :                  : Show GOTV server status.
+tv_stop                                  : cmd      :                  : Stops the GOTV broadcast [-instance <inst> ]
+tv_stoprecord                            : cmd      :                  : Stops GOTV demo recording [-instance <inst> ]
+tv_timeout                               : 30       :                  : GOTV connection timeout in seconds.
+tv_title                                 : 0        :                  : Set title for GOTV spectator UI
+tv_transmitall                           : 1        : , "rep"          : Transmit all entities (not only director view)
+tv_window_size                           : 16       :                  : Specifies the number of seconds worth of frames that the tv replay system should keep in memory. Increasing this greatly increa
+unbind                                   : cmd      :                  : Unbind a key.
+unbindall                                : cmd      :                  : Unbind all keys.
+unbindalljoystick                        : cmd      :                  : Unbind all joystick keys.
+unbindallmousekeyboard                   : cmd      :                  : Unbind all mouse / keyboard keys.
+unpause                                  : cmd      :                  : Unpause the game.
+use                                      : cmd      :                  : Use a particular weapon  Arguments: <weapon_name>
+user                                     : cmd      :                  : Show user data.
+users                                    : cmd      :                  : Show user info for players on server.
+vehicle_flushscript                      : cmd      :                  : Flush and reload all vehicle scripts
+version                                  : cmd      :                  : Print version info string.
+vietnam_airstrike_cooldown               : 45       : , "sv", "cheat", "nf", "rep" : Defines cooldown of airstrike in non-GunGame modes.
+vietnam_airstrike_cooldown_gg            : 30       : , "sv", "cheat", "nf", "rep" : Defines cooldown of airstrike in GunGame.
+vietnam_airstrike_independant            : 0        : , "sv", "rep"    : If true, airstrike limits are independant from gamerules
+vietnam_allowdual_primary                : 1        : , "sv"           :
+vietnam_allowdual_secondary              : 1        : , "sv"           :
+vietnam_api_log_requests                 : 0        : , "a", "sv"      : 1 = API requests will be logged to console, 2 = API requests that are sensitive will also be logged to console (DANGER! Only se
+vietnam_api_reauthenticate               : cmd      :                  : Reauth with HTTP API.
+vietnam_api_url                          : 0        : , "sv"           : URL of the Vietnam api (e.g. http://localhost:3000)
+vietnam_ballistics_approximation_segments : 3        : , "sv", "cheat", "rep" : How accurate will be bullet trajectory approximation
+vietnam_ballistics_enabled               : 0        : , "sv", "rep"    : Turn on bullet ballistic system.
+vietnam_ballistics_first_segment_always_accurate : 1        : , "sv", "cheat", "rep" : Disable bullet drop for first segment in order to reduce total number of segments
+vietnam_ballistics_reduction             : 1        : , "sv", "cheat", "rep" : How much to reduce bullet damage, velocity and max fly distance
+vietnam_ballistics_show_stats            : 0        : , "sv", "cheat", "rep" : Show bullet simulation info
+vietnam_bayonet_equip_enabled            : 1        : , "sv", "rep"    : Enables or disables bayonet feature.
+vietnam_body_armor                       : 0        : , "sv", "rep"    : Force Body Armor: 1. Always on. -1. Always off. .
+vietnam_bot_health_regen                 : 1        : , "sv", "nf", "rep" : Toggles bot health regeneration functionality
+vietnam_conquest_start_tickets_us        : 250      : , "sv", "nf", "rep" : Set initial amount of tickets for United States team in Conquest
+vietnam_conquest_start_tickets_vc        : 250      : , "sv", "nf", "rep" : Set initial amount of tickets for Viet Cong team in Conquest
+vietnam_cq_respawntime                   : 5        : , "sv", "nf", "rep" : Set respawn time in seconds for Conquest
+vietnam_ctf_maxscore                     : 7        : , "sv", "nf", "rep" : Set max score to win the match
+vietnam_ctf_respawntime                  : 5        : , "sv", "nf", "rep" : Set respawn time in seconds for Capture The Flag
+vietnam_demolition_respawntime           : 5        : , "sv", "nf", "rep" : Set respawn time in seconds for Demolition
+vietnam_domination_maxscore              : 200      : , "sv", "nf", "rep" : Set max score to win the Domination
+vietnam_drop_both_dual_weapons           : 0        : , "sv"           :
+vietnam_dshk_ammo                        : 300      : , "sv", "rep"    : Ammo of this turret.
+vietnam_dshk_damage                      : 55       : , "sv", "rep"    : Base bullet damage.
+vietnam_dshk_firerate                    : 8        : , "sv", "rep"    : Rounds per second.
+vietnam_dshk_health                      : 500      : , "sv", "rep"    : Health of this turret.
+vietnam_dshk_overheat_rate               : 0        : , "sv", "rep"    : At which rate dshk will increase overheat level.
+vietnam_dshk_spread                      : 0        : , "sv", "rep"    : Minigun spray in degrees from forward.
+vietnam_force_weapon                     : cmd      :                  : Force specific weapon on player
+vietnam_gg_tiers_max                     : 28       : , "sv", "cheat", "nf", "rep" : Defines amount of available weapon tiers.
+vietnam_gungame_infinite_ammo            : 1        : , "sv", "rep"    : Specifies whether the player has infinite total ammo in gungame
+vietnam_health_regen                     : 1        : , "sv", "nf", "rep" : Toggles player health regeneration functionality
+vietnam_health_regen_amount              : 1        : , "sv", "nf", "rep" : Defines the amount of additional health granted to players upon regeneration
+vietnam_health_regen_delay               : 1        : , "sv", "nf", "rep" : Defines the amount of time (in seconds) before players start regenerating health after recieving damage
+vietnam_health_regen_speed               : 0        : , "sv", "nf", "rep" : Defines the amount of time (in seconds) before players are granted additional health
+vietnam_health_threshold                 : 50       : , "sv", "nf", "rep" : Defines the threshold health after which start regeneration
+vietnam_health_threshold_healed          : 100      : , "sv", "nf", "rep" : Defines the bigger threshold health after which start regeneration when player was healed
+vietnam_health_threshold_healed_medic_self : 75       : , "sv", "nf", "rep" : Threshold health regeneration when medic heals himself
+vietnam_kc_pickup_cooldown               : 1        : , "sv"           : Cooldown time before tag is available for pickup
+vietnam_killconfirmed_maxscore           : 50       : , "sv", "nf", "rep" : Set max score to win the match
+vietnam_lms_respawntime                  : 5        : , "sv", "nf", "rep" : Set respawn time in seconds for Last Man Standing
+vietnam_loadout_file_name                : 0        : , "sv", "nf", "rep" : Usage: vietnam_loadout_file_name vietnam_loadout.txt
+vietnam_lts_respawntime                  : 5        : , "sv", "nf", "rep" : Set respawn time in seconds for Last Team Standing
+vietnam_m134_ammo                        : 500      : , "sv", "rep"    : Ammo of this turret.
+vietnam_m134_damage                      : 55       : , "sv", "rep"    : Base bullet damage.
+vietnam_m134_delay_attack                : 0        : , "sv", "rep"    : How in seconds should start attack.
+vietnam_m134_firerate                    : 20       : , "sv", "rep"    : Rounds per second.
+vietnam_m134_health                      : 500      : , "sv", "rep"    : Health of this turret.
+vietnam_m134_overheat_rate               : 0        : , "sv", "rep"    : At which rate M134 Browning will increase overheat level.
+vietnam_m134_spread                      : 0        : , "sv", "rep"    : Minigun spray in degrees from forward.
+vietnam_m2browning_ammo                  : 300      : , "sv", "rep"    : Ammo of this turret.
+vietnam_m2browning_damage                : 55       : , "sv", "rep"    : Base bullet damage.
+vietnam_m2browning_firerate              : 8        : , "sv", "rep"    : Rounds per second.
+vietnam_m2browning_health                : 500      : , "sv", "rep"    : Health of this turret.
+vietnam_m2browning_overheat_rate         : 0        : , "sv", "rep"    : At which rate M2 Browning will increase overheat level.
+vietnam_m2browning_spread                : 0        : , "sv", "rep"    : Minigun spray in degrees from forward.
+vietnam_m40rr_ammo                       : 30       : , "sv", "rep"    : Ammo of this turret.
+vietnam_m40rr_damage                     : 250      : , "sv", "rep"    : Rocket explosion damage.
+vietnam_m40rr_firerate                   : 0        : , "sv", "rep"    : Rounds per second.
+vietnam_m40rr_health                     : 500      : , "sv", "rep"    : Health of this turret.
+vietnam_m40rr_overheat_rate              : 0        : , "sv", "rep"    : At which rate m40rr will increase overheat level.
+vietnam_m40rr_radius                     : 384      : , "sv"           : Rocket explosion radius.
+vietnam_m40rr_spread                     : 0        : , "sv", "rep"    : Spray in degrees from forward.
+vietnam_max_mines_placed                 : 3        : , "sv", "rep"    : Determines the amount of mines you can place until you cant place anymore.
+vietnam_mine_min_install_radius          : 26       : , "sv", "rep"    :
+vietnam_mountedgun_cooldown_rate         : 0        : , "sv"           : How quickly mounted gun will cool down after overheating.
+vietnam_mountedgun_explosion_damage      : 40       : , "sv"           : Explosion Damage.
+vietnam_mountedgun_explosion_radius      : 20       : , "sv"           : Explosion Radius.
+vietnam_mountedgun_max_distance          : 8192     : , "sv", "rep"    : Max shooting distance.
+vietnam_mountedgun_no_dismount_period    : 0        : , "sv", "rep"    : Do not let player dismount from this gun when pressing move buttons during given period in seconds.
+vietnam_mountedgun_overheat_time         : 2        : , "sv"           : How long mounted gun will remain in overheated state.
+vietnam_mountedgun_velocity_shoot_rocket : 2500     : , "sv", "rep"    : Velocity of shoot rocket for recoilless rifles turrets.
+vietnam_oddball_maxscore                 : 180      : , "sv", "nf", "rep" : Set max seconds to win the match
+vietnam_oddball_pickup_cooldown          : 1        : , "sv"           : Cooldown time before oddball is available for pickup
+vietnam_player_breathing                 : 1        : , "sv", "rep"    :
+vietnam_poison_aftermath_damage          : 3        : , "sv"           :
+vietnam_poison_aftermath_damage_duration : 4        : , "sv"           :
+vietnam_poison_aftermath_damage_interval : 0        : , "sv"           :
+vietnam_poison_cloud_initial_damage_radius : 0        : , "sv"           :
+vietnam_poison_direct_damage             : 3        : , "sv"           :
+vietnam_projectile_duds                  : 1        : , "sv", "rep"    : Allows to fire projectiles at close ranges without turning into duds.
+vietnam_prone_recoil                     : 1        : , "sv", "rep"    : Recoil Reduction While Prone.
+vietnam_reload_explosion_manifest        : cmd      :                  :
+vietnam_ricochets_enabled                : 1        : , "sv", "cheat", "rep" :
+vietnam_spawnableprop_damage_by_owner    : 0        : , "sv"           : Decide whether spawnable prop can be damaged by the owner.
+vietnam_spg9_ammo                        : 30       : , "sv", "rep"    : Ammo of this turret.
+vietnam_spg9_damage                      : 250      : , "sv", "rep"    : Rocket explosion damage.
+vietnam_spg9_firerate                    : 0        : , "sv", "rep"    : Rounds per second.
+vietnam_spg9_health                      : 500      : , "sv", "rep"    : Health of this turret.
+vietnam_spg9_overheat_rate               : 0        : , "sv", "rep"    : At which rate spg9 will increase overheat level.
+vietnam_spg9_radius                      : 384      : , "sv"           : Rocket explosion radius.
+vietnam_spg9_spread                      : 0        : , "sv", "rep"    : Spray in degrees from forward.
+vietnam_wave_challenge_frequency         : 0        : , "sv", "nf", "rep" : Defines the frequency of challenge waves (i.e. defines x, where every x wave is a challenge wave)
+vietnam_zombies_allow_player_bots        : 0        : , "sv", "rep"    : Allow player bots to spawn in Zombie Mode.
+vietnam_zombies_assist_reward            : 30       : , "sv", "nf", "rep" : Credits earned for assist kill to another player.
+vietnam_zombies_currency_bonus_headshot  : 0        : , "sv", "nf", "rep" : Gives a currency bonus for a headshot.
+vietnam_zombies_currency_win_wave        : 0        : , "sv", "nf", "rep" : Provide currency income to all players at the end of each waves, the value will increase with each wave.
+vietnam_zombies_default_carry_weight     : 15       : , "sv", "nf", "rep" : Default weapon carry weight for players in Zombie Mode. They can extend it using special items.
+vietnam_zombies_difficulty_mode          : 1        : , "sv", "nf"     : Switch between four (0-3) difficulty modes.
+vietnam_zombies_extramagazine_price      : 3000     : , "sv", "nf", "rep" : Cost of extra magazine perk in zombie mode.
+vietnam_zombies_extranades_price         : 500      : , "sv", "nf", "rep" : Cost of extra nades perk in zombie mode.
+vietnam_zombies_extraprops_price         : 1000     : , "sv", "nf", "rep" : Cost of extra spawnable props perk in zombie mode.
+vietnam_zombies_extraweight_price        : 1500     : , "sv", "nf", "rep" : Cost of extra carry weight perk in zombie mode.
+vietnam_zombies_giveammo_reward          : 250      : , "sv", "nf", "rep" : Credits earned for giving ammo to another player.
+vietnam_zombies_givehealth_reward        : 250      : , "sv", "nf", "rep" : Credits earned for healing another player.
+vietnam_zombies_interim_time             : 60       : , "sv", "nf", "rep" : Duration of interim period in for Zombie Mode
+vietnam_zombies_max_props                : 5        : , "sv", "nf", "rep" : Max of placed props.
+vietnam_zombies_parachute_price          : 2000     : , "sv", "nf", "rep" : Cost of parachute perk in zombie mode.
+vietnam_zombies_perk_multiplier          : 2        : , "sv", "nf", "rep" : Base for perk price scaling in zombie mode. a in a^x, where x is perk level.
+vietnam_zombies_scaling_multiplier_count_coop_easy : 1        : , "sv", "nf"     : Increase zombie count by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_count_coop_hard : 2        : , "sv", "nf"     : Increase zombie count by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_count_coop_normal : 1        : , "sv", "nf"     : Increase zombie count by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_count_coop_vietnam : 2        : , "sv", "nf"     : Increase zombie count by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_count_solo_easy : 0        : , "sv", "nf"     : Increase zombie count by this percentage when playing solo easy mode.
+vietnam_zombies_scaling_multiplier_count_solo_hard : 1        : , "sv", "nf"     : Increase zombie count by this percentage when playing solo hard mode.
+vietnam_zombies_scaling_multiplier_count_solo_normal : 1        : , "sv", "nf"     : Increase zombie count by this percentage when playing solo normal mode.
+vietnam_zombies_scaling_multiplier_count_solo_vietnam : 1        : , "sv", "nf"     : Increase zombie count by this percentage when playing solo vietnam mode.
+vietnam_zombies_scaling_multiplier_damage_coop_easy : 1        : , "sv", "nf"     : Increase zombie damage by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_damage_coop_hard : 1        : , "sv", "nf"     : Increase zombie damage by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_damage_coop_normal : 1        : , "sv", "nf"     : Increase zombie damage by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_damage_coop_vietnam : 1        : , "sv", "nf"     : Increase zombie damage by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_damage_solo_easy : 1        : , "sv", "nf"     : Increase zombie damage by this percentage when playing solo easy mode.
+vietnam_zombies_scaling_multiplier_damage_solo_hard : 1        : , "sv", "nf"     : Increase zombie damage by this percentage when playing solo hard mode.
+vietnam_zombies_scaling_multiplier_damage_solo_normal : 1        : , "sv", "nf"     : Increase zombie damage by this percentage when playing solo normal mode.
+vietnam_zombies_scaling_multiplier_damage_solo_vietnam : 1        : , "sv", "nf"     : Increase zombie damage by this percentage when playing solo vietnam mode.
+vietnam_zombies_scaling_multiplier_health_coop_easy : 1        : , "sv", "nf"     : Increase zombie health by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_health_coop_hard : 1        : , "sv", "nf"     : Increase zombie health by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_health_coop_normal : 1        : , "sv", "nf"     : Increase zombie health by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_health_coop_vietnam : 1        : , "sv", "nf"     : Increase zombie health by this percentage based on amount of players.
+vietnam_zombies_scaling_multiplier_health_solo_easy : 1        : , "sv", "nf"     : Increase zombie health by this percentage when playing solo easy mode.
+vietnam_zombies_scaling_multiplier_health_solo_hard : 1        : , "sv", "nf"     : Increase zombie health by this percentage when playing solo hard mode.
+vietnam_zombies_scaling_multiplier_health_solo_normal : 1        : , "sv", "nf"     : Increase zombie health by this percentage when playing solo normal mode.
+vietnam_zombies_scaling_multiplier_health_solo_vietnam : 1        : , "sv", "nf"     : Increase zombie health by this percentage when playing solo vietnam mode.
+vietnam_zombies_startcash                : 0        : , "sv", "nf", "rep" : Base cash amount in Zombie Mode
+vietnam_zombies_startwave                : 0        : , "sv", "nf", "rep" : Start Zombie Mode from this wave
+view_punch_decay                         : 5        : , "sv", "cheat", "rep" : Decay factor exponent for view punch
+view_recoil_tracking                     : 0        : , "sv", "cheat", "rep" : How closely the view tracks with the aim punch from weapon recoil
+violence_ablood                          : 1        :                  : Draw alien blood
+violence_agibs                           : 1        :                  : Show alien gib entities
+violence_hblood                          : 1        :                  : Draw human blood
+violence_hgibs                           : 1        :                  : Show human gib entities
+vis_force                                : 0        : , "sv", "cheat"  :
+vismon_poll_frequency                    : 0        : , "sv", "cheat"  :
+vismon_trace_limit                       : 12       : , "sv", "cheat"  :
+voice_debugfeedbackfrom                  : 0        :                  :
+voice_inputfromfile                      : 0        :                  : Get voice input from 'voice_input.wav' rather than from the microphone.
+voice_mute                               : cmd      :                  : Mute a specific Steam user
+voice_player_speaking_delay_threshold    : 0        : , "sv", "cheat"  :
+voice_recordtofile                       : 0        :                  : Record mic data and decompressed voice data into 'voice_micdata.wav' and 'voice_decompressed.wav'
+voice_reset_mutelist                     : cmd      :                  : Reset all mute information for all players who were ever muted.
+voice_serverdebug                        : 0        : , "sv"           :
+voice_show_mute                          : cmd      :                  : Show whether current players are muted.
+voice_unmute                             : cmd      :                  : Unmute a specific Steam user, or `all` to unmute all connected players.
+voice_xsend_debug                        : 0        :                  :
+vox_reload                               : cmd      :                  : Reload sentences.txt file
+voxeltree_box                            : cmd      :                  : View entities in the voxel-tree inside box <Vector(min), Vector(max)>.
+voxeltree_playerview                     : cmd      :                  : View entities in the voxel-tree at the player position.
+voxeltree_sphere                         : cmd      :                  : View entities in the voxel-tree inside sphere <Vector(center), float(radius)>.
+voxeltree_view                           : cmd      :                  : View entities in the voxel-tree.
+vphys_sleep_timeout                      : cmd      :                  : set sleep timeout: large values mean stuff won't ever sleep
+vprof                                    : cmd      :                  : Toggle VProf profiler
+vprof_cachemiss                          : cmd      :                  : Toggle VProf cache miss checking
+vprof_cachemiss_off                      : cmd      :                  : Turn off VProf cache miss checking
+vprof_cachemiss_on                       : cmd      :                  : Turn on VProf cache miss checking
+vprof_counters                           : 0        :                  :
+vprof_counters_show_minmax               : 0        :                  :
+vprof_dump_counters                      : cmd      :                  : Dump vprof counters to the console
+vprof_dump_groupnames                    : cmd      :                  : Write the names of all of the vprof groups to the console.
+vprof_dump_oninterval                    : 0        :                  : Interval (in seconds) at which vprof will batch up data and dump it to the console.
+vprof_dump_spikes                        : 0        :                  : Framerate at which vprof will begin to dump spikes to the console. 0 = disabled, negative to reset after dump
+vprof_dump_spikes_budget_group           : 0        :                  : Budget gtNode to start report from when doing a dump spikes
+vprof_dump_spikes_hiearchy               : 0        :                  : Set to 1 to get a hierarchy report whith vprof_dump_spikes
+vprof_dump_spikes_node                   : 0        :                  : Node to start report from when doing a dump spikes
+vprof_dump_spikes_terse                  : 0        :                  : Whether to use most terse output
+vprof_generate_report                    : cmd      :                  : Generate a report to the console.
+vprof_generate_report_AI                 : cmd      :                  : Generate a report to the console.
+vprof_generate_report_AI_only            : cmd      :                  : Generate a report to the console.
+vprof_generate_report_budget             : cmd      :                  : Generate a report to the console based on budget group.
+vprof_generate_report_hierarchy          : cmd      :                  : Generate a report to the console.
+vprof_generate_report_hierarchy_per_frame_and_count_only : cmd      :                  : Generate a minimal hiearchical report to the console.
+vprof_generate_report_map_load           : cmd      :                  : Generate a report to the console.
+vprof_off                                : cmd      :                  : Turn off VProf profiler
+vprof_on                                 : cmd      :                  : Turn on VProf profiler
+vprof_playback_average                   : cmd      :                  : Average the next N frames.
+vprof_playback_start                     : cmd      :                  : Start playing back a recorded .vprof file.
+vprof_playback_step                      : cmd      :                  : While playing back a .vprof file, step to the next tick.
+vprof_playback_stepback                  : cmd      :                  : While playing back a .vprof file, step to the previous tick.
+vprof_playback_stop                      : cmd      :                  : Stop playing back a recorded .vprof file.
+vprof_record_start                       : cmd      :                  : Start recording vprof data for playback later.
+vprof_record_stop                        : cmd      :                  : Stop recording vprof data
+vprof_reset                              : cmd      :                  : Reset the stats in VProf profiler
+vprof_reset_peaks                        : cmd      :                  : Reset just the peak time in VProf profiler
+vprof_scope_entity_gamephys              : 0        : , "sv"           :
+vprof_scope_entity_thinks                : 0        : , "sv"           :
+vprof_server_spike_threshold             : 999      :                  :
+vprof_server_thread                      : 0        :                  :
+vprof_think_limit                        : 0        : , "sv"           :
+vprof_to_csv                             : cmd      :                  : Convert a recorded .vprof file to .csv.
+vprof_vtune_group                        : cmd      :                  : enable vtune for a particular vprof group ('disable' to disable)
+vx_do_not_throttle_events                : 0        :                  : Force VXConsole updates every frame; smoother vprof data on PS3 but at a slight (~0.2ms) perf cost.
+wc_air_edit_further                      : cmd      :                  : When in WC edit mode and editing air nodes,  moves position of air node crosshair and placement location further away from play
+wc_air_edit_nearer                       : cmd      :                  : When in WC edit mode and editing air nodes,  moves position of air node crosshair and placement location nearer to from player
+wc_air_node_edit                         : cmd      :                  : When in WC edit mode, toggles laying down or air nodes instead of ground nodes
+wc_create                                : cmd      :                  : When in WC edit mode, creates a node where the player is looking if a node is allowed at that location for the currently select
+wc_destroy                               : cmd      :                  : When in WC edit mode, destroys the node that the player is nearest to looking at.  (The node will be highlighted by a red box).
+wc_destroy_undo                          : cmd      :                  : When in WC edit mode restores the last deleted node
+wc_link_edit                             : cmd      :                  :
+weapon_accuracy_forcespread              : 0        : , "sv", "rep"    : Force spread to the specified value.
+weapon_accuracy_nospread                 : 0        : , "sv", "rep"    : Disable weapon inaccuracy spread
+weapon_accuracy_shotgun_spread_patterns  : 0        : , "sv", "rep"    :
+weapon_air_spread_scale                  : 1        : , "sv", "rep"    : Scale factor for jumping inaccuracy, set to 0 to make jumping accuracy equal to standing
+weapon_auto_cleanup_time                 : 0        : , "sv"           : If set to non-zero, weapons will delete themselves after the specified time (in seconds) if no players are near.
+weapon_bash_abort_reload                 : 1        : , "sv", "rep"    : If enabled, bashing will abort reload.
+weapon_damage_falloff                    : 1        : , "sv", "rep"    : Modify weapon damage falloff reduction.
+weapon_firemode_attack_hold              : 1        : , "sv", "rep"    : Allows to fire by holding MOUSE1 button in semi-automatic and burst mode.
+weapon_flamethrower_debug                : 0        : , "sv"           :
+weapon_lpo50_distance                    : 512      : , "sv", "rep"    :
+weapon_lpo50_radius                      : 5        : , "sv", "rep"    :
+weapon_lpo50_zombie_distance             : 1024     : , "sv", "rep"    :
+weapon_lpo50_zombie_radius               : 7        : , "sv", "rep"    :
+weapon_m9a1_distance                     : 512      : , "sv", "rep"    :
+weapon_m9a1_radius                       : 5        : , "sv", "rep"    :
+weapon_m9a1_zombie_distance              : 1024     : , "sv", "rep"    :
+weapon_m9a1_zombie_radius                : 7        : , "sv", "rep"    :
+weapon_molotov_maxdetonateslope          : 30       : , "sv", "rep"    : Maximum angle of slope on which the molotov will detonate
+weapon_near_empty_sound                  : 1        : , "sv", "cheat", "rep" :
+weapon_recoil_decay1_exp                 : 3        : , "sv", "rep"    : Decay factor exponent for weapon recoil
+weapon_recoil_decay2_exp                 : 8        : , "sv", "rep"    : Decay factor exponent for weapon recoil
+weapon_recoil_decay2_lin                 : 18       : , "sv", "rep"    : Decay factor (linear term) for weapon recoil
+weapon_recoil_decay_coefficient          : 2        : , "sv", "rep"    :
+weapon_recoil_scale                      : 1        : , "sv", "rep"    : Overall scale factor for recoil. Used to reduce recoil on specific platforms
+weapon_recoil_scale_motion_controller    : 1        : , "sv", "cheat", "rep" : Overall scale factor for recoil. Used to reduce recoil.  Only for motion controllers
+weapon_recoil_vel_decay                  : 4        : , "sv", "rep"    : Decay factor for weapon recoil velocity
+weapon_recoil_view_punch_extra           : 0        : , "sv", "rep"    : Additional (non-aim) punch added to view from recoil
+weapon_reticle_knife_show                : 0        : , "sv", "rep"    : When enabled will show knife reticle on clients. Used for game modes requiring target id display when holding a knife.
+weapon_show_grenade_crosshair            : 1        : , "sv", "rep"    : Enable or disable crosshair for grenades. Enforced by server.
+weapon_showproficiency                   : 0        : , "sv"           :
+weapon_sniper_scope_motion               : 1        : , "sv", "rep"    : Enables or disables lowering sniper weapon viewmodel while in air.
+weapon_sound_falloff_multiplier          : 1        : , "sv", "cheat", "rep" : Scaling for falloff of weapon firing sounds
+whitelistcmd                             : cmd      :                  : Runs a whitelisted command.
+wipe_nav_attributes                      : cmd      :                  : Clear all nav attributes of selected area.
+workshop_download_addon                  : cmd      :                  : Downloads an addon by ID. Mounts it automatically, but does not store in .txt mount cache.
+workshop_mount_addon                     : cmd      :                  : Mounts an addon and stores it in .txt mount cache.
+workshop_start                           : cmd      :                  : Get the latest version of installed maps and start random one.
+workshop_unmount_addon                   : cmd      :                  : Unmounts addon and removes it from .txt mount cache.
+workshop_update_all                      : cmd      :                  : Updates all installed items.
+wpn_reload_script                        : cmd      :                  : Debug command for reloading weapon scripts. Note that reloading must happen on both client & server.
+writeid                                  : cmd      :                  : Writes a list of permanently-banned user IDs to banned_user.cfg.
+writeip                                  : cmd      :                  : Save the ban list to banned_ip.cfg.
+xbox_autothrottle                        : 1        : , "a", "sv"      :
+xbox_steering_deadzone                   : 0        : , "sv"           :
+xbox_throttlebias                        : 100      : , "a", "sv"      :
+xbox_throttlespoof                       : 200      : , "a", "sv"      :
+xc_crouch_debounce                       : 0        : , "sv"           :
+z_elevator_in_air                        : 0        : , "sv"           :
+zombie_armor_attack_damage               : 7        : , "sv"           :
+zombie_armor_attack_melee_range          : 60       : , "sv"           :
+zombie_armor_attack_range                : 40       : , "sv"           :
+zombie_armor_cash_reward                 : 0        : , "sv"           :
+zombie_armor_dropped_ammo_remove_time    : 20       : , "sv"           :
+zombie_armor_dropped_medkit_remove_time  : 20       : , "sv"           :
+zombie_armor_price                       : 1000     : , "sv", "nf", "rep" : Cost of armor in zombie mode.
+zombie_armor_run_speed                   : 170      : , "sv"           :
+zombie_armor_spawn_medic_chance          : 0        : , "sv"           :
+zombie_armor_spawn_support_chance        : 0        : , "sv"           :
+zombie_armor_walk_speed                  : 40       : , "sv"           :
+zombie_bloat_attack_damage               : 20       : , "sv"           :
+zombie_bloat_attack_melee_range          : 40       : , "sv"           :
+zombie_bloat_attack_range                : 40       : , "sv"           :
+zombie_bloat_cash_reward                 : 0        : , "sv"           :
+zombie_bloat_fart_cloud_lifetime         : 20       : , "sv"           :
+zombie_bloat_fart_radius                 : 96       : , "sv"           :
+zombie_bloat_fart_timer                  : 20       : , "sv"           :
+zombie_bloat_run_speed                   : 90       : , "sv"           :
+zombie_bloat_vomit_cone_radius           : 45       : , "sv"           :
+zombie_bloat_vomit_damage                : 7        : , "sv"           :
+zombie_bloat_vomit_duration              : 5        : , "sv"           :
+zombie_bloat_vomit_timer                 : 15       : , "sv"           :
+zombie_bloat_vomit_trigger_dist          : 96       : , "sv"           :
+zombie_bloat_walk_speed                  : 40       : , "sv"           :
+zombie_bomber_attack_damage              : 20       : , "sv"           :
+zombie_bomber_attack_melee_range         : 40       : , "sv"           :
+zombie_bomber_attack_range               : 40       : , "sv"           :
+zombie_bomber_cash_reward                : 0        : , "sv"           :
+zombie_bomber_charge_speed_suicide       : 250      : , "sv"           :
+zombie_bomber_damage                     : 100      : , "sv"           :
+zombie_bomber_radius                     : 70       : , "sv"           :
+zombie_bomber_run_speed                  : 170      : , "sv"           :
+zombie_bomber_walk_speed                 : 40       : , "sv"           :
+zombie_buffalo_attack_bleeding_rate      : 1        : , "sv"           :
+zombie_buffalo_attack_damage             : 50       : , "sv"           :
+zombie_buffalo_attack_melee_range        : 108      : , "sv"           :
+zombie_buffalo_attack_range              : 40       : , "sv"           :
+zombie_buffalo_cash_reward               : 0        : , "sv"           :
+zombie_burning_attack_damage             : 15       : , "sv"           :
+zombie_burning_attack_melee_range        : 160      : , "sv"           :
+zombie_burning_attack_range              : 30       : , "sv"           :
+zombie_burning_cash_reward               : 0        : , "sv"           :
+zombie_burning_flame_damage              : 3        : , "sv"           :
+zombie_burning_flame_damage_interval     : 0        : , "sv"           :
+zombie_burning_ignite_damage_lifetime    : 4        : , "sv"           :
+zombie_burning_run_speed                 : 200      : , "sv"           :
+zombie_burning_walk_speed                : 40       : , "sv"           :
+zombie_cash_reward                       : 0        : , "sv"           :
+zombie_charge_speed_buffalo              : 270      : , "sv"           :
+zombie_cheat_setcredits                  : cmd      :                  : CHEAT: Set the player's current Zombie Mode credits
+zombie_cheat_setwave                     : cmd      :                  : CHEAT: Set current wave number
+zombie_climb_height                      : 180      : , "sv"           : Max climbing height.
+zombie_crow_acceleration                 : 500      : , "sv"           :
+zombie_crow_attack_damage                : 3        : , "sv"           :
+zombie_crow_attack_melee_range           : 17       : , "sv"           :
+zombie_crow_cash_reward                  : 0        : , "sv"           :
+zombie_crow_horiz_damping                : 2        : , "sv"           :
+zombie_crow_hover_height                 : 200      : , "sv"           :
+zombie_crow_hover_height_delta           : 50       : , "sv"           :
+zombie_crow_vert_damping                 : 1        : , "sv"           :
+zombie_dog_attack_damage                 : 5        : , "sv"           :
+zombie_dog_attack_melee_range            : 160      : , "sv"           :
+zombie_dog_attack_range                  : 20       : , "sv"           :
+zombie_dog_cash_reward                   : 0        : , "sv"           :
+zombie_dog_run_speed                     : 170      : , "sv"           :
+zombie_elephant_attack_damage            : 300      : , "sv"           :
+zombie_elephant_attack_melee_range       : 96       : , "sv"           :
+zombie_elephant_attack_range             : 96       : , "sv"           :
+zombie_elephant_cash_reward              : 0        : , "sv"           :
+zombie_elephant_run_speed                : 75       : , "sv"           :
+zombie_elephant_spawn_rat_timer          : 3        : , "sv"           :
+zombie_elephant_walk_speed               : 75       : , "sv"           :
+zombie_gun_allow_drop_weapon             : 0        : , "sv"           :
+zombie_gun_attack_damage                 : 35       : , "sv"           :
+zombie_gun_attack_melee_range            : 80       : , "sv"           :
+zombie_gun_attack_range                  : 30       : , "sv"           :
+zombie_gun_cash_reward                   : 0        : , "sv"           :
+zombie_gun_drop_ammo_chance              : 0        : , "sv"           :
+zombie_gun_dropped_ammo_remove_time      : 20       : , "sv"           :
+zombie_gun_refire_cooldown_time          : 15       : , "sv"           :
+zombie_gun_run_speed                     : 170      : , "sv"           :
+zombie_gun_walk_speed                    : 40       : , "sv"           :
+zombie_havok_attack_damage               : 55       : , "sv"           :
+zombie_havok_attack_melee_range          : 75       : , "sv"           :
+zombie_havok_attack_range                : 40       : , "sv"           :
+zombie_havok_cash_reward                 : 0        : , "sv"           :
+zombie_havok_drop_ammo_chance            : 0        : , "sv"           :
+zombie_havok_dropped_ammo_remove_time    : 20       : , "sv"           :
+zombie_havok_refire_cooldown_time        : 15       : , "sv"           :
+zombie_havok_run_speed                   : 170      : , "sv"           :
+zombie_havok_walk_speed                  : 40       : , "sv"           :
+zombie_health_armor                      : 150      : , "sv"           :
+zombie_health_bloat                      : 350      : , "sv"           :
+zombie_health_bomber                     : 325      : , "sv"           :
+zombie_health_buffalo                    : 1500     : , "sv"           :
+zombie_health_burning                    : 250      : , "sv"           :
+zombie_health_crow                       : 20       : , "sv"           :
+zombie_health_dog                        : 75       : , "sv"           :
+zombie_health_elephant                   : 10000    : , "sv"           :
+zombie_health_gun                        : 550      : , "sv"           :
+zombie_health_havoc                      : 3000     : , "sv"           :
+zombie_health_orange                     : 2000     : , "sv"           :
+zombie_health_ranged                     : 300      : , "sv"           :
+zombie_health_rat                        : 1        : , "sv"           :
+zombie_health_regular                    : 100      : , "sv"           :
+zombie_health_screamer                   : 500      : , "sv"           :
+zombie_health_slasher                    : 225      : , "sv"           :
+zombie_jump_height                       : 50       : , "sv"           :
+zombie_mode_debug                        : 0        : , "sv", "cheat"  :
+zombie_mode_stop                         : 0        : , "sv", "cheat"  :
+zombie_orange_attack_damage              : 65       : , "sv"           :
+zombie_orange_attack_melee_range         : 40       : , "sv"           :
+zombie_orange_attack_range               : 40       : , "sv"           :
+zombie_orange_blob_damage                : 50       : , "sv"           : Amount of damage taken from the blob when player steps on it.
+zombie_orange_blob_slide                 : 0        : , "sv"           : If on, bile blobs dropped by zombie will slide on the slopes.
+zombie_orange_blob_vaporize_time         : 60       : , "sv"           : Time in seconds before blob vaporizes.
+zombie_orange_cash_reward                : 0        : , "sv"           :
+zombie_orange_run_speed                  : 90       : , "sv"           :
+zombie_orange_vomit_attack_duration      : 4        : , "sv"           : Duration of vomit attack (for how long zombie is vomitting).
+zombie_orange_vomit_cone_radius          : 45       : , "sv"           :
+zombie_orange_vomit_damage               : 7        : , "sv"           :
+zombie_orange_vomit_effect_duration      : 5        : , "sv"           : Duration of vomit effect on screen when player is affected by it.
+zombie_orange_vomit_timer                : 15       : , "sv"           :
+zombie_orange_vomit_trigger_dist         : 96       : , "sv"           :
+zombie_orange_walk_speed                 : 40       : , "sv"           :
+zombie_ranged_attack_damage              : 25       : , "sv"           :
+zombie_ranged_attack_melee_range         : 40       : , "sv"           :
+zombie_ranged_attack_range               : 40       : , "sv"           :
+zombie_ranged_bolt_damage                : 30       : , "sv"           :
+zombie_ranged_bolt_velocity              : 1500     : , "sv"           :
+zombie_ranged_cash_reward                : 0        : , "sv"           :
+zombie_ranged_charge_speed_lowhealth     : 250      : , "sv"           :
+zombie_ranged_run_speed                  : 170      : , "sv"           :
+zombie_ranged_walk_speed                 : 40       : , "sv"           :
+zombie_rat_attack_damage                 : 2        : , "sv"           :
+zombie_rat_attack_melee_range            : 120      : , "sv"           :
+zombie_rat_attack_range                  : 120      : , "sv"           :
+zombie_rat_cash_reward                   : 0        : , "sv"           :
+zombie_rat_explode_time                  : 30       : , "sv"           :
+zombie_rat_run_speed                     : 250      : , "sv"           :
+zombie_regular_attack_damage             : 7        : , "sv"           :
+zombie_regular_attack_melee_range        : 40       : , "sv"           :
+zombie_regular_attack_range              : 40       : , "sv"           :
+zombie_regular_drop_cash_chance          : 0        : , "sv"           :
+zombie_regular_dropped_cash_remove_time  : 0        : , "sv"           :
+zombie_run_speed                         : 170      : , "sv"           :
+zombie_run_speed_buffalo                 : 170      : , "sv"           :
+zombie_screamer_attack_damage            : 23       : , "sv"           :
+zombie_screamer_attack_melee_range       : 40       : , "sv"           :
+zombie_screamer_attack_range             : 40       : , "sv"           :
+zombie_screamer_cash_reward              : 0        : , "sv"           :
+zombie_screamer_run_speed                : 170      : , "sv"           :
+zombie_screamer_scream_duration_damage   : 2        : , "sv"           :
+zombie_screamer_scream_interval_damage   : 0        : , "sv"           :
+zombie_screamer_scream_radius            : 320      : , "sv"           :
+zombie_screamer_walk_speed               : 40       : , "sv"           :
+zombie_slasher_attack_damage             : 15       : , "sv"           :
+zombie_slasher_attack_range              : 30       : , "sv"           :
+zombie_slasher_attack_range_melee        : 80       : , "sv"           :
+zombie_slasher_cash_reward               : 0        : , "sv"           :
+zombie_slasher_run_speed                 : 170      : , "sv"           :
+zombie_slasher_walk_speed                : 40       : , "sv"           :
+zombie_step_height                       : 18       : , "sv"           :
+zombie_walk_speed                        : 40       : , "sv"           :
+zombie_walk_speed_buffalo                : 40       : , "sv"           :
+--------------
+2477 total convars/concommands

--- a/serverlist.csv
+++ b/serverlist.csv
@@ -25,6 +25,7 @@ ins
 ios
 l4d
 l4d2
+mcv
 nd
 nmrih
 ns


### PR DESCRIPTION
Add `mcv-cvarlist.txt` (2477 convars/concommands) generated from a running Military Conflict: Vietnam dedicated server (Steam appid `1136190`).

Also adds `mcv` entry to `serverlist.csv`.

Related: GameServerManagers/LinuxGSM#4902